### PR TITLE
Update `ubuntu oneiric 32` link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -152,7 +152,7 @@
     <td>http://jschneiderhan.posterous.com/updatedbuntu-1104-server-i386-vagrant-box-with-418</td>
   </tr>
   <tr>
-    <th scope="row">ubuntu oneiric 32</th>
+    <th scope="row">base (ubuntu oneiric 32)</th>
     <td>http://vagrant.cedric-ziel.com/oneiric32.box</td>
   </tr>
   <tr>


### PR DESCRIPTION
Replaced old dead link with a new working box  from http://vagrant.cedric-ziel.com/
