### PR TITLE
Fixed `centos 5.6 32` box's link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -77,7 +77,7 @@
   </tr>
   <tr>
     <th scope="row">centos 5.6 32</th>
-    <td>http://32httpyum.mnxsolutions.com/vagrant/centos_56_32.box</td>
+    <td>http://yum.mnxsolutions.com/vagrant/centos_56_32.box</td>
   </tr>
   <tr>
     <th scope="row">puppet debian lenny 32</th>


### PR DESCRIPTION
This fix the link to download the `centos 5.6 32` box.
