### PR TITLE
Fix typo in mathie maverick 64 URL

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -221,7 +221,7 @@
   </tr>
   <tr>
     <th scope="row">ubuntu maverick 64</th>
-    <td>http:/64http/mathie-vagrant-boxes.s3.amazonaws.com/maverick64.box</td>
+    <td>http://mathie-vagrant-boxes.s3.amazonaws.com/maverick64.box</td>
   </tr>
   <tr>
     <th scope="row">centos 5.5</th>


### PR DESCRIPTION
Looks like there was a pasting/middle click error. :)
