### PR TITLE
removed centos 6.0 64, because the image is down

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -52,10 +52,6 @@
     <td>http://vagrant.pouss.in/archlinux_2012-07-02.box</td>
   </tr>
   <tr>
-    <th scope="row">centos 6.0 64</th>
-    <td>http://dl.dropbox.com/u/36836372/centos6_64-veewee.BoxesCentOS-6.0-x86_64</td>
-  </tr>
-  <tr>
     <th scope="row">CentOS 6 32bit</th>
     <td>http://hackd.net/dist/vagrant/centos6_32.box</td>
   </tr>


### PR DESCRIPTION
curl -I http://dl.dropbox.com/u/36836372/centos6_64-veewee.BoxesCentOS-6.0-x86_64
HTTP/1.1 404 NOT FOUND

Best Regards,
Felix
