### PR TITLE
Add CentOS 6.3 x86_64 minimal and remove no vagrant URL

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -48,6 +48,10 @@
 
 <table>
   <tr>
+    <th scope="row">CentOS 6.3 x86_64 minimal (2012-07-11) - 309,6 MB</th>
+    <td>https://dl.dropbox.com/u/7225008/Vagrant/CentOS-6.3-x86_64-minimal.box</td>
+  </tr>
+  <tr>
     <th scope="row">Arch Linux 64 (2012-07-02)</th>
     <td>http://vagrant.pouss.in/archlinux_2012-07-02.box</td>
   </tr>
@@ -172,15 +176,11 @@
     <td>http://dl.dropbox.com/u/9227672/centos-5.6-x86_64-netinstall-4.1.6.box</td>
   </tr>
   <tr>
-    <th scope="row">centos 6 x86_64</th>
-    <td>http://isoredirect.centos.org/centos/6/isos/x86_64http86_64/</td>
-  </tr>
-  <tr>
     <th scope="row">archlinux</th>
     <td>http://sourceforge.net/projects/vagrantarchlinx/files/files2011.08.19/archlinux_2011.08.19.box/download</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 6</th>
+    <th scope="row">CentOS 6 [No puppet]</th>
     <td>https://vagrant-centos-6.s3.amazonaws.com/centos-6.box</td>
   </tr>
   <tr>


### PR DESCRIPTION
Add info for vagrant box that doesn't have puppet installed.
