### PR TITLE
Wrong links for Debian images from puppetlabs

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -104,7 +104,7 @@
   </tr>
   <tr>
     <th scope="row">Debian Lenny 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/Debian_Lenny_64.box</td>
+    <td>http://puppetlabs.s3.amazonaws.com/pub/debian_lenny_64.box</td>
     <td>386MB</td>
   </tr>
   <tr>
@@ -114,7 +114,7 @@
   </tr>
   <tr>
     <th scope="row">Debian Squeeze 64</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/Squeeze64.box</td>
+    <td>http://puppetlabs.s3.amazonaws.com/pub/squeeze64.box</td>
     <td>540MB</td>
   </tr>
   <tr>


### PR DESCRIPTION
Both links for Debian images from puppetlabs were wrong. Files should 
be lowercase (squeeze64, debian_lenny_64) instead of camelcase.
