### PR TITLE
Added Ubuntu precise64 box with Guest Additions 4.1.18

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -267,6 +267,11 @@
     <td>http://putitinthepizza.com/boxes/centos58-x86_64.box</td>
     <td>995MB</td>
   </tr>
+    <tr>
+    <th scope="row">Ubuntu 12.04.1 LTS x86_64 (Guest Additions 4.1.18)</th>
+    <td>http://dl.dropbox.com/u/1537815/precise64.box</td>
+    <td>568MB</td>
+  </tr>
 </table>
 
 <div id="footer">


### PR DESCRIPTION
Hi,
I've updated the base Ubuntu precise64 box to ship with Virtualbox Guest Additions 4.1.18, so the box is compatible with the latest Virtualbox version and fix the issue about creating a file in the share folder (https://github.com/mitchellh/vagrant/issues/1045).
Hope it helps.
