### PR TITLE
Adding 2 OpenBSD 5.0 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -153,6 +153,16 @@
     <td>283MB</td>
   </tr>
   <tr>
+    <th scope="row">OpenBSD 5.0 (amd64) puppet chef pkg ports</th>
+    <td>https://github.com/downloads/stefancocora/openbsd_amd64-vagrant/openbsd50_amd64.box</td>
+    <td>279.7MB</td>
+  </tr>
+  <tr>
+    <th scope="row">OpenBSD 5.0 (i386) puppet chef pkg ports</th>
+    <td>https://github.com/downloads/stefancocora/openbsd_i386-vagrant/openbsd50_i386.box</td>
+    <td>266.3MB</td>
+  </tr>
+  <tr>
     <th scope="row">OpenBSD 5.0 (i386)</th>
     <td>https://s3-eu-west-1.amazonaws.com/rosstimson-vagrant-boxes/openbsd50-i386.box</td>
     <td>211MB</td>


### PR DESCRIPTION
I'm adding 2 openbsd 5.0 base boxes: amd64 and i386 that come with puppet, chef, pkg and ports
