### PR TITLE
New CentOS 5.8 x86_64 base box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -264,7 +264,7 @@
   </tr>
   <tr>
     <th scope="row">CentOS 5.8 x86_64</th>
-    <td>https://dl.dropbox.com/u/17738575/centos58-x86_64.box</td>
+    <td>https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box</td>
     <td>957MB</td>
   </tr>
 </table>


### PR DESCRIPTION
Link to the old CentOS 5.8 box at putitinthepizza was broken. 

Used RVM so that the official puppet RPMs and the chef gem could coexist.
