### PR TITLE
Added updated CentOS 6.3 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -53,6 +53,11 @@
     <td>310MB</td>
   </tr>
   <tr>
+    <th scope="row">CentOS 6.3 x86_64 + Chef 10.14.2 + VirtualBox 4.1.22 (with guest additions)</th>
+    <td>https://s3.amazonaws.com/itmat-public/centos-6.3-chef-10.14.2.box</td>
+    <td>445MB</td>
+  </tr>
+  <tr>
     <th scope="row">OmniOS (r151002)</th>
     <td>http://omnios.omniti.com/media/omnios-latest.box</td>
     <td>837MB</td>


### PR DESCRIPTION
Added entry for CentOS 6.3, updated for  VirtualBox 4.1.22 and pre-installed for Chef 10.14.2
