### PR TITLE
CentOS 6.3 32bit (Ruby 1.8.7 & Chef 10.14.2)

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -53,16 +53,6 @@
     <td>702MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 6.3 x86_64 minimal</th>
-    <td>https://dl.dropbox.com/u/7225008/Vagrant/CentOS-6.3-x86_64-minimal.box</td>
-    <td>310MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 6.3 x86_64 + Chef 10.14.2 + VirtualBox 4.1.22 (with guest additions)</th>
-    <td>https://s3.amazonaws.com/itmat-public/centos-6.3-chef-10.14.2.box</td>
-    <td>445MB</td>
-  </tr>
-  <tr>
     <th scope="row">OmniOS (r151002)</th>
     <td>http://omnios.omniti.com/media/omnios-latest.box</td>
     <td>837MB</td>
@@ -98,11 +88,6 @@
     <td>657MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 5.6 32</th>
-    <td>http://yum.mnxsolutions.com/vagrant/centos_56_32.box</td>
-    <td>804MB</td>
-  </tr>
-  <tr>
     <th scope="row">Debian Lenny 32 puppet</th>
     <td>http://s3-eu-west-1.amazonaws.com/glassesdirect-boxen/Debian/Debian_Lenny_32_puppet_backport.box</td>
     <td>345MB</td>
@@ -131,11 +116,6 @@
     <th scope="row">RHEL 6 64 puppet</th>
     <td>http://puppetlabs.s3.amazonaws.com/pub/rhel60_64.box</td>
     <td>576MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 4 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/centos4_64.box</td>
-    <td>540MB</td>
   </tr>
   <tr>
     <th scope="row">SLES 11sp1 64 puppet</th>
@@ -188,24 +168,9 @@
     <td>385MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 5.7 64</th>
-    <td>http://dl.dropbox.com/u/8072848/centos-5.7-x86_64.box</td>
-    <td>521MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 5.6 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/centos56_64.box</td>
-    <td>614MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Minimal CentOS 6.0</th>
-    <td>http://dl.dropbox.com/u/9227672/CentOS-6.0-x86_64-netboot-4.1.6.box</td>
-    <td>362MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Minimal CentOS 5.6</th>
-    <td>http://dl.dropbox.com/u/9227672/centos-5.6-x86_64-netinstall-4.1.6.box</td>
-    <td>277MB</td>
+    <th scope="row">Archlinux 2011.08.19 - 64</th>
+    <td>http://ftp.heanet.ie/mirrors/sourceforge/v/project/va/vagrantarchlinx/2011.08.19/archlinux_2011.08.19.box</td>
+    <td>539MB</td>
   </tr>
   <tr>
     <th scope="row">Archlinux 2011-08-19</th>
@@ -213,14 +178,69 @@
     <td>565MB</td>
   </tr>
   <tr>
+    <th scope="row">CentOS 6.3 x86_64 minimal</th>
+    <td>https://dl.dropbox.com/u/7225008/Vagrant/CentOS-6.3-x86_64-minimal.box</td>
+    <td>310MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 6.3 x86_64 + Chef 10.14.2 + VirtualBox 4.1.22 (with guest additions)</th>
+    <td>https://s3.amazonaws.com/itmat-public/centos-6.3-chef-10.14.2.box</td>
+    <td>445MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 6.3 32bit (Ruby 1.8.7 &amp; Chef 10.14.2)</th>
+    <td>https://www.dropbox.com/s/3guas37yai7o6lx/centos63-32.box</td>
+    <td>443MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Minimal CentOS 6.0</th>
+    <td>http://dl.dropbox.com/u/9227672/CentOS-6.0-x86_64-netboot-4.1.6.box</td>
+    <td>362MB</td>
+  </tr>
+  <tr>
     <th scope="row">CentOS 6</th>
     <td>https://vagrant-centos-6.s3.amazonaws.com/centos-6.box</td>
     <td>582MB</td>
   </tr>
   <tr>
-    <th scope="row">Archlinux 2011.08.19 - 64</th>
-    <td>http://ftp.heanet.ie/mirrors/sourceforge/v/project/va/vagrantarchlinx/2011.08.19/archlinux_2011.08.19.box</td>
-    <td>539MB</td>
+    <th scope="row">CentOS 5.8 x86_64</th>
+    <td>https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box</td>
+    <td>957MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 5.7 64</th>
+    <td>http://dl.dropbox.com/u/8072848/centos-5.7-x86_64.box</td>
+    <td>521MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Minimal CentOS 5.6</th>
+    <td>http://dl.dropbox.com/u/9227672/centos-5.6-x86_64-netinstall-4.1.6.box</td>
+    <td>277MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 5.6 32</th>
+    <td>http://yum.mnxsolutions.com/vagrant/centos_56_32.box</td>
+    <td>804MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 5.6 64 puppet</th>
+    <td>http://puppetlabs.s3.amazonaws.com/pub/centos56_64.box</td>
+    <td>614MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 5.5 64</th>
+    <td>http://dl.dropbox.com/u/15307300/vagrant-0.7-centos-64-base.box</td>
+    <td>499MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 4 64 puppet</th>
+    <td>http://puppetlabs.s3.amazonaws.com/pub/centos4_64.box</td>
+    <td>540MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Opscode centos 5</th>
+    <td>http://opscode-vagrant-boxes.s3.amazonaws.com/centos5-gems.box</td>
+    <td>458MB</td>
   </tr>
   <tr>
     <th scope="row">Gentoo 64</th>
@@ -238,19 +258,9 @@
     <td>367MB</td>
   </tr>
   <tr>
-    <th scope="row">Opscode centos 5</th>
-    <td>http://opscode-vagrant-boxes.s3.amazonaws.com/centos5-gems.box</td>
-    <td>458MB</td>
-  </tr>
-  <tr>
     <th scope="row">Ubuntu Maverick 64</th>
     <td>http://mathie-vagrant-boxes.s3.amazonaws.com/maverick64.box</td>
     <td>515MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 5.5 64</th>
-    <td>http://dl.dropbox.com/u/15307300/vagrant-0.7-centos-64-base.box</td>
-    <td>499MB</td>
   </tr>
   <tr>
     <th scope="row">Debian squeeze 32</th>
@@ -296,11 +306,6 @@
     <th scope="row">openSuse 12.1 x64</th>
     <td>https://github.com/jtperry/OpenSuseVagrantBox</td>
     <td>665MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 5.8 x86_64</th>
-    <td>https://dl.dropbox.com/u/17738575/CentOS-5.8-x86_64.box</td>
-    <td>957MB</td>
   </tr>
     <tr>
     <th scope="row">Ubuntu 12.04.1 LTS x86_64 (Guest Additions 4.1.18)</th>


### PR DESCRIPTION
Added my CentOS 6.3 32bit (Ruby 1.8.7 & Chef 10.14.2) box.
Changed the order of the list to put all the CentOS boxes together in version order to make the correct version easier to find.
