### PR TITLE
Added a vanilla Debian 6.0.6 box 32 bit

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -317,6 +317,11 @@
     <td>https://dl.dropbox.com/u/14292474/vagrantboxes/precise64-ruby-1.9.3-p194.box</td>
     <td>892MB</td>
   </tr>
+  <tr>
+    <th scope="row">Debian Squeeze 6.0.6 32 - Vanilla (No Ruby, no puppet, only Chef 10.14 from omnibus installer)</th>
+    <td>https://dl.dropbox.com/u/2289657/squeeze32-vanilla.box</td>
+    <td>276MB</td>
+  </tr>
 
 </table>
 


### PR DESCRIPTION
I've created the box using [this procedure](https://github.com/jedi4ever/veewee/blob/master/doc/vagrant.md) and used [this template](https://github.com/jedi4ever/veewee/tree/master/templates/Debian-6.0.6-i386-netboot) as base.

I removed the Debian chef package (pretty old version) and puppet (not needed for me).

I'm using this box to try some chef cookbooks using chef-server and I don't want to have any tool installed.
