### PR TITLE
Added centos 6.2 and 6.3 32bit puppet boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -319,12 +319,12 @@
   </tr>
   <tr>
     <th scope="row">CentOS 6.2 32bit (puppet)</th>
-    <td>https://dl.dropbox.com/sh/9rldlpj3cmdtntc/56JW-DSK35/centos-62-32bit-puppet.box?dl=1</td>
+    <td>https://dl.dropbox.com/sh/9rldlpj3cmdtntc/56JW-DSK35/centos-62-32bit-puppet.box</td>
     <td>501MB</td>
   </tr>
   <tr>
     <th scope="row">CentOS 6.3 32bit (puppet)</th>
-    <td>https://dl.dropbox.com/sh/9rldlpj3cmdtntc/chqwU6EYaZ/centos-63-32bit-puppet.box?dl=1</td>
+    <td>https://dl.dropbox.com/sh/9rldlpj3cmdtntc/chqwU6EYaZ/centos-63-32bit-puppet.box</td>
     <td>651MB</td>
   </tr>
 </table>


### PR DESCRIPTION
I've added a centos 6.2 and 6.3 32bit box with puppet provisioning.
