### PR TITLE
Added Debian Squeeze 64 with Puppet 2.7

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -133,6 +133,11 @@
     <td>540MB</td>
   </tr>
   <tr>
+    <th scope="row">Debian Squeeze 64 with Puppet 2.7</th>
+    <td>http://andrew.mcnaughty.com/downloads/squeeze64_puppet27.box</td>
+    <td>448MB</td>
+  </tr>
+  <tr>
     <th scope="row">RHEL 6 64 puppet</th>
     <td>http://puppetlabs.s3.amazonaws.com/pub/rhel60_64.box</td>
     <td>576MB</td>


### PR DESCRIPTION
Added a Debian Squeeze 64 Image which I've prepared from a Minimal Netboot distribution image, and then added puppetlabs apt repository and puppet pinned at version 2.7.*

Useful for puppet 2.7's increased warnings about forward compatibility issues for migrating puppet configurations to puppet 3.x.x.
