### PR TITLE
remove entry for incomplete centos 6 base box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -218,11 +218,6 @@
     <td>565MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 6</th>
-    <td>https://vagrant-centos-6.s3.amazonaws.com/centos-6.box</td>
-    <td>582MB</td>
-  </tr>
-  <tr>
     <th scope="row">Archlinux 2011.08.19 - 64</th>
     <td>http://ftp.heanet.ie/mirrors/sourceforge/v/project/va/vagrantarchlinx/2011.08.19/archlinux_2011.08.19.box</td>
     <td>539MB</td>


### PR DESCRIPTION
This CentOS 6 box does not have puppet installed, and as such doesn't meet the requirements to be considered a Vagrant base box according to these guidelines: http://vagrantup.com/v1/docs/base_boxes.html

I propose that the url be removed from the page, especially since there are multiple other CentOS 6 images listed that work great.
