### PR TITLE
Adding a minimal Debian Wheezy basebox

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -58,6 +58,11 @@
     <td>272MB</td>
   </tr>
   <tr>
+    <th scope="row">Debian Wheezy amd64 minimal (base install, no puppet, no chef, no ruby, no gems, just an install')</th>
+    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy-minimal.box</td>
+    <td>342.5MB</td>
+  </tr>
+  <tr>
     <th scope="row">Ubuntu 12.04 server amd64 (Drupal Ready)</th>
     <td>http://ubuntuone.com/790qH5nb7cFe2CLQkGiTpz</td>
     <td>702MB</td>


### PR DESCRIPTION
There was no minimal Debian Wheezy basebox on the page, and that is what I wanted. So I created it and then decided to give it back for others to use. Its a base install from the latest debian-installer release, with no puppet, chef, ruby, gems installed. A barebones box.

You can find the definition here: https://github.com/leapcode/minimal-debian-vagrant
