### PR TITLE
Added FreeBSD 9.1 amd64 UFS System + corrected download links

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -57,12 +57,12 @@
   <tr>
     <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
     <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
-    <td>298MB</td>
+    <td>228MB</td>
   </tr>
   <tr>
     <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.1.22)</th>
     <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_zfs.box</td>
-    <td>298MB</td>
+    <td>251MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu Server 12.04 amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>


### PR DESCRIPTION
Added another Vagrant box for FreeBSD 9.1 amd64 using UFS. Corrected download links as well as updated the listed sizes for these files.
