### PR TITLE
Update freebsd/zfs box url

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -56,8 +56,8 @@
   <tbody>
   <tr>
     <th scope="row">FreeBSD 9.1 amd64 - ZFS on root (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64-zfs.box</td>
-    <td>298MB</td>
+    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_zfs.box</td>
+    <td>234.9MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu Server 12.04 amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>


### PR DESCRIPTION
As upstream renamed the file, old link shows a 404 error.

See https://github.com/xironix/freebsd-vagrant/downloads
