### PR TITLE
Add updated CentOS 6.3 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -56,13 +56,13 @@
   <tbody>
   <tr>
     <th scope="row">CentOS 6.3 x86_64 Minimal (VirtualBox Guest Additions 4.2.6, Chef 10.16.4, Puppet 3.0.2)</th>
-    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-x86_64-v20121228.box</td>
-    <td>443MB</td>
+    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-x86_64-v20130101.box</td>
+    <td>455MB</td>
   </tr>
   <tr>
     <th scope="row">CentOS 6.3 i386 Minimal (VirtualBox Guest Additions 4.2.6, Chef 10.16.4, Puppet 3.0.2)</th>
-    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-i386-v20121228.box</td>
-    <td>357MB</td>
+    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-i386-v20130101.box</td>
+    <td>386MB</td>
   </tr>
   <tr>
     <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>


### PR DESCRIPTION
Newer CentOS 6.3 minimal boxes with updated VirtualBox guest additions, chef, and puppet versions.
