### PR TITLE
Fix broken minimal-wheezy link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -81,7 +81,7 @@
   </tr>
   <tr>
     <th scope="row">Debian Wheezy amd64 minimal (base install, no puppet, no chef, no ruby, no gems, just an install')</th>
-    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy-minimal.box</td>
+    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/minimal-wheezy.box</td>
     <td>342.5MB</td>
   </tr>
   <tr>


### PR DESCRIPTION
The box URL for minimal-wheezy from #57 is wrong.

Found this out the hard way, patched with the correct link.
