### PR TITLE
Added CentOS 5.6 box with Ruby, Puppet & Chef installed from RPMs

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -235,6 +235,11 @@
     <td>614MB</td>
   </tr>
   <tr>
+    <th scope="row">CentOS 5.6 64 Packages (puppet 2.6.10 &amp; chef 0.10.6 from RPM, VirtualBox 4.2.0)</th>
+    <td>https://dl.dropbox.com/u/7196/vagrant/CentOS-56-x64-packages-puppet-2.6.10-chef-0.10.6.box</td>
+    <td>420MB</td>
+  </tr>
+  <tr>
     <th scope="row">Minimal CentOS 6.0</th>
     <td>http://dl.dropbox.com/u/9227672/CentOS-6.0-x86_64-netboot-4.1.6.box</td>
     <td>362MB</td>


### PR DESCRIPTION
Added my CentOS 5.6 64bit box that installs puppet, chef & ruby deps from RPMs.
Matching veewee definitions are in https://github.com/jedi4ever/veewee/pull/431
