### PR TITLE
Updated Ubuntu Oneiric links

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -215,14 +215,9 @@
     <td>211MB</td>
   </tr>
   <tr>
-    <th scope="row">Ubuntu Oneiric 32</th>
-    <td>http://vagrant.cedric-ziel.com/oneiric32.box</td>
-    <td>340MB</td>
-  </tr>
-  <tr>
     <th scope="row">Ubuntu Oneiric 64</th>
-    <td>http://images.ansolabs.com/vagrant/oneiric64.box</td>
-    <td>385MB</td>
+    <td>https://github.com/shaftoe/vagrant-ubuntu-oneiric64/raw/master/oneiric64.box</td>
+    <td>324MB</td>
   </tr>
   <tr>
     <th scope="row">CentOS 5.7 64</th>


### PR DESCRIPTION
Hi, I needed Oneiric 64 and I saw link(s) on vagrantobox.es were broken, so I created a Oneiric 64 base box and just put it here on GitHub. I've removed Oneirc 32 link too because is broken
