### PR TITLE
Remove broken links for Oneiric

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -215,16 +215,6 @@
     <td>211MB</td>
   </tr>
   <tr>
-    <th scope="row">Ubuntu Oneiric 32</th>
-    <td>http://vagrant.cedric-ziel.com/oneiric32.box</td>
-    <td>340MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Ubuntu Oneiric 64</th>
-    <td>http://images.ansolabs.com/vagrant/oneiric64.box</td>
-    <td>385MB</td>
-  </tr>
-  <tr>
     <th scope="row">CentOS 5.7 64</th>
     <td>http://dl.dropbox.com/u/8072848/centos-5.7-x86_64.box</td>
     <td>521MB</td>


### PR DESCRIPTION
I got errors over multiple days.

For oneiric32:

```
[vagrant] Downloading with Vagrant::Downloaders::HTTP...
[vagrant] Downloading box: http://vagrant.cedric-ziel.com/oneiric32.box
Bad status code: 404
```

For oneiric64:

```
[vagrant] Downloading with Vagrant::Downloaders::HTTP...
An error occurred while trying to download the specified box. This most
often happens if there is no internet connection or the address is
invalid.
```
