### PR TITLE
Add base box for vagrant-heroku.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,6 +55,11 @@
   </thead>
   <tbody>
   <tr>
+    <th scope="row">Heroku Celadon Cedar</th>
+    <td>http://dl.dropbox.com/u/1906634/heroku.box</td>
+    <td>555MB</td>
+  </tr>
+  <tr>
     <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
     <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
     <td>228MB</td>


### PR DESCRIPTION
I have a vagrant basebox at https://github.com/ejholmes/vagrant-heroku that's built to match the stack used for Heroku's Celadon Cedar stack.
