### PR TITLE
Added links to Windows Server 2008 R2 base boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,6 +55,16 @@
   </thead>
   <tbody>
   <tr>
+    <th scope="row">Windows Server 2008 R2 - Datacentre full (Puppet, VirtualBox 4.2.4)</th>
+    <td>http://dl.dropbox.com/u/58604/vagrant/win2k8r2.box</td>
+    <td>3541MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Windows Server 2008 R2 - Datacentre core (Puppet, VirtualBox 4.2.4)</th>
+    <td>http://dl.dropbox.com/u/58604/vagrant/win2k8r2-core.box</td>
+    <td>1225MB</td>
+  </tr>
+  <tr>
     <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
     <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
     <td>228MB</td>


### PR DESCRIPTION
hosting some windows server base boxes on dropbox; they're large but they work well using puppet and windows-vagrant
