### PR TITLE
Fixing URL for Debian Wheezy box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -81,8 +81,8 @@
   </tr>
   <tr>
     <th scope="row">Debian Wheezy amd64 minimal (base install, no puppet, no chef, no ruby, no gems, just an install')</th>
-    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy-minimal.box</td>
-    <td>342.5MB</td>
+    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy.box</td>
+    <td>380.6MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu 12.04 server amd64 (Drupal Ready)</th>


### PR DESCRIPTION
Fixing URL for Debian Wheezy box - the old one wasn't found anymore at GitHub
