### PR TITLE
Updated links to FreeBSD 9.1 UFS/ZFS Boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -45,7 +45,7 @@
  <span>$ </span>vagrant up
 </pre>
 
-<p>The list of boxes was last updated on October 29th, 2012.</p>
+<p>The list of boxes was last updated on January 3rd, 2013.</p>
 
 <p><b>NEW</b>: Table is sortable by clicking on the column headers.</p>
 
@@ -55,14 +55,14 @@
   </thead>
   <tbody>
   <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
-    <td>228MB</td>
+    <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>https://s3.amazonaws.com/VagrantBoxen/freebsd_amd64_ufs.box</td>
+    <td>258.4MB</td>
   </tr>
   <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_zfs.box</td>
-    <td>251MB</td>
+    <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>https://s3.amazonaws.com/VagrantBoxen/freebsd_amd64_zfs.box</td>
+    <td>268.4MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu Server 12.04 amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>


### PR DESCRIPTION
Since GitHub has deprecated its download tab, I had to move these boxes to Amazon S3. The links have been updated accordingly.
