### PR TITLE
A new Debian 6 Squeeze x64 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,6 +55,11 @@
   </thead>
   <tbody>
   <tr>
+    <th scope="row">Debian 6 Squeeze x64 configured according to documentation</th>
+    <td>http://www.emken.biz/vagrant-boxes/debsqueeze64.box</td>
+    <td>408MB</td>
+  </tr>
+  <tr>
     <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
     <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
     <td>228MB</td>


### PR DESCRIPTION
Debian 6 x64 is an extremely popular OS for web servers. I was surprised that several of the Deb 6 boxes were slightly misconfigured or configured in a way that could cause issues. I eventually just created my own box to fix those issues. I vow to fix issues with my box as they come up. I also actively use my boxes for real development so there is a good chance me or my team members will find issues and fix them.
