### PR TITLE
Removing link to box that no longer exists.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -210,11 +210,6 @@
     <td>266.3MB</td>
   </tr>
   <tr>
-    <th scope="row">OpenBSD 5.0 (i386)</th>
-    <td>https://s3-eu-west-1.amazonaws.com/rosstimson-vagrant-boxes/openbsd50-i386.box</td>
-    <td>211MB</td>
-  </tr>
-  <tr>
     <th scope="row">Ubuntu Oneiric 32</th>
     <td>http://vagrant.cedric-ziel.com/oneiric32.box</td>
     <td>340MB</td>


### PR DESCRIPTION
I am no longer hosting this box as I have not maintained it in a long
time and most folk just create their own or use VeeWee these days.

The S3 bucket now no longer exists.
