### PR TITLE
CentOS 5.8 x86_64 minimal box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -354,6 +354,11 @@
     <td>http://tag1consulting.com/files/centos-5.8-x86-64-minimal.box</td>
     <td>349MB</td>
   </tr>
+  <tr>
+    <th scope="row">CentOS 5.9 x86_64 minimal + guest additions, puppet, chef</th>
+    <td>http://tag1consulting.com/files/centos-5.9-x86-64-minimal.box</td>
+    <td>356MB</td>
+  </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Add a new CentOS 5.8 x86_64 box since the current version listed is quite large at 957M (this one is down to 349M).
