### PR TITLE
Centos 5.7 Box Link Replaced

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -226,7 +226,7 @@
   </tr>
   <tr>
     <th scope="row">CentOS 5.7 64</th>
-    <td>http://dl.dropbox.com/u/8072848/centos-5.7-x86_64.box</td>
+    <td>http://www.lyricalsoftware.com/downloads/centos-5.7-x86_64.box</td>
     <td>521MB</td>
   </tr>
   <tr>


### PR DESCRIPTION
The CentOS 5.7 box on the web page doesn't support puppet as a provisioner, and had broken DNS (someone's internal office network). I've repackaged a Vagrant for CentOS 5.7, pointed DNS to google's 8.8.4.4, and installed puppet 2.7 and facter - meaning puppet can be used as a provisioner with CentOS 5.7!
