### PR TITLE
Add Official Ubuntu Cloud Images

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -349,6 +349,36 @@
     <td>https://github.com/downloads/roderik/VagrantQuantal64Box/quantal64.box</td>
     <td>402MB</td>
   </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-amd64-disk1.box</td>
+    <td>258M</td>
+  </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-i386-disk1.box</td>
+    <td>258M</td>
+  </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 12.10 daily Cloud Image amd64 (Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/quantal/current/quantal-server-cloudimg-vagrant-amd64-disk1.box</td>
+    <td>258M</td>
+  </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 12.10 daily Cloud Image i386 (Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/quantal/current/quantal-server-cloudimg-vagrant-i386-disk1.box</td>
+    <td>258M</td>
+  </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 13.04 daily Cloud Image amd64 (Development release, Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/raring/current/raring-server-cloudimg-vagrant-amd64-disk1.box</td>
+    <td>257M</td>
+  </tr>
+  <tr>
+    <th scope="row">Official Ubuntu 13.04 daily Cloud Image i386 (Development release, Guest Additions)</th>
+    <td>http://cloud-images.ubuntu.com/raring/current/raring-server-cloudimg-vagrant-i386-disk1.box</td>
+    <td>257M</td>
+  </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Canonical is now publishing Vagrant Cloud Images, hosted on cloud-images.ubuntu.com.
