### PR TITLE
Removed deprecated GitHub download links

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,16 +55,6 @@
   </thead>
   <tbody>
   <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
-    <td>228MB</td>
-  </tr>
-  <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_zfs.box</td>
-    <td>251MB</td>
-  </tr>
-  <tr>
     <th scope="row">Ubuntu Server 12.04 amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>
     <td>https://dl.dropbox.com/u/1543052/Boxes/UbuntuServer12.04amd64.box</td>
     <td>267MB</td>
@@ -78,11 +68,6 @@
     <th scope="row">Debian Squeeze amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>
     <td>https://dl.dropbox.com/u/1543052/Boxes/DebianSqueeze64.box</td>
     <td>272MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Debian Wheezy amd64 minimal (base install, no puppet, no chef, no ruby, no gems, just an install')</th>
-    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy-minimal.box</td>
-    <td>342.5MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu 12.04 server amd64 (Drupal Ready)</th>
@@ -198,16 +183,6 @@
     <th scope="row">Aegir-up Debian (Stable 64-bit)</th>
     <td>http://ergonlogic.com/files/boxes/debian-current.box</td>
     <td>283MB</td>
-  </tr>
-  <tr>
-    <th scope="row">OpenBSD 5.0 (amd64) puppet chef pkg ports</th>
-    <td>https://github.com/downloads/stefancocora/openbsd_amd64-vagrant/openbsd50_amd64.box</td>
-    <td>279.7MB</td>
-  </tr>
-  <tr>
-    <th scope="row">OpenBSD 5.0 (i386) puppet chef pkg ports</th>
-    <td>https://github.com/downloads/stefancocora/openbsd_i386-vagrant/openbsd50_i386.box</td>
-    <td>266.3MB</td>
   </tr>
   <tr>
     <th scope="row">OpenBSD 5.0 (i386)</th>
@@ -343,11 +318,6 @@
     <th scope="row">Ubuntu precise 64 (Ruby 1.9.3 &amp; Chef 10.12)</th>
     <td>https://dl.dropbox.com/u/14292474/vagrantboxes/precise64-ruby-1.9.3-p194.box</td>
     <td>892MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Ubuntu 12.10 Quantal x86_64 (Guest Additions 4.2.2)</th>
-    <td>https://github.com/downloads/roderik/VagrantQuantal64Box/quantal64.box</td>
-    <td>402MB</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
GitHub no longer supports downloads from the repository so they have been removed.
