### PR TITLE
Fix/remove broken GitHub download links

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -55,14 +55,14 @@
   </thead>
   <tbody>
   <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_ufs.box</td>
-    <td>228MB</td>
+    <th scope="row">FreeBSD 9.1 amd64 - UFS (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>https://s3.amazonaws.com/VagrantBoxen/freebsd_amd64_ufs.box</td>
+    <td>258MB</td>
   </tr>
   <tr>
-    <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.1.22)</th>
-    <td>https://github.com/downloads/xironix/freebsd-vagrant/freebsd_amd64_zfs.box</td>
-    <td>251MB</td>
+    <th scope="row">FreeBSD 9.1 amd64 - ZFS (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>https://s3.amazonaws.com/VagrantBoxen/freebsd_amd64_zfs.box</td>
+    <td>268MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu Server 12.04 amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>
@@ -78,11 +78,6 @@
     <th scope="row">Debian Squeeze amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>
     <td>https://dl.dropbox.com/u/1543052/Boxes/DebianSqueeze64.box</td>
     <td>272MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Debian Wheezy amd64 minimal (base install, no puppet, no chef, no ruby, no gems, just an install')</th>
-    <td>https://github.com/downloads/leapcode/minimal-debian-vagrant/wheezy-minimal.box</td>
-    <td>342.5MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu 12.04 server amd64 (Drupal Ready)</th>


### PR DESCRIPTION
GitHub no longer supports downloads from the repository and some people
already have moved their boxes away or dropped them completely.

The patch from pull request #84 won't apply anymore.
