### PR TITLE
Added boxes of Fedora 17 to the list

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -215,6 +215,16 @@
     <td>380.6MB</td>
   </tr>
   <tr>
+    <th scope="row">Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>http://dl.dropbox.com/u/6002490/vagrant/beefymiracle32.box</td>
+    <td>804.25MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Fedora 17 x86_64 (Puppet, Chef, VirtualBox 4.2.6)</th>
+    <td>http://dl.dropbox.com/u/6002490/vagrant/beefymiracle64.box</td>
+    <td>768.49MB</td>
+  </tr>
+  <tr>
     <th scope="row">Fedora 18 x86_64 Minimal (with Puppet, VirtualBox 4.2.6 and rpmfusion yum repo)</th>
     <td>https://dl.dropbox.com/s/gsxue3k7bw2m8b1/fedora18_x86_64_minimal.box</td>
     <td>483MB</td>


### PR DESCRIPTION
- Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6);
- Fedora 17 x86_64 (Puppet, Chef, VirtualBox 4.2.6).

These boxes are created and tested with [**veewee**](https://github.com/jedi4ever/veewee) , builded on Mac OS X 10.6 Snow Leopard.
