### PR TITLE
Bring the puppetlabs boxes into the modern era

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -85,11 +85,6 @@
     <td>539MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 4 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/centos4_64.box</td>
-    <td>540MB</td>
-  </tr>
-  <tr>
     <th scope="row">CentOS 5.5 64</th>
     <td>http://dl.dropbox.com/u/15307300/vagrant-0.7-centos-64-base.box</td>
     <td>499MB</td>
@@ -103,11 +98,6 @@
     <th scope="row">CentOS 5.6 64 Packages (puppet 2.6.10 & chef 0.10.6 from RPM, VirtualBox 4.2.0)</th>
     <td>https://dl.dropbox.com/u/7196/vagrant/CentOS-56-x64-packages-puppet-2.6.10-chef-0.10.6.box</td>
     <td>420MB</td>
-  </tr>
-  <tr>
-    <th scope="row">CentOS 5.6 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/centos56_64.box</td>
-    <td>614MB</td>
   </tr>
   <tr>
     <th scope="row">CentOS 5.7 64</th>
@@ -173,11 +163,6 @@
     <th scope="row">Debian Lenny 32 puppet</th>
     <td>http://s3-eu-west-1.amazonaws.com/glassesdirect-boxen/Debian/Debian_Lenny_32_puppet_backport.box</td>
     <td>345MB</td>
-  </tr>
-  <tr>
-    <th scope="row">Debian Lenny 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/debian_lenny_64.box</td>
-    <td>386MB</td>
   </tr>
   <tr>
     <th scope="row">Debian squeeze 32</th>
@@ -330,9 +315,34 @@
     <td>603MB</td>
   </tr>
   <tr>
-    <th scope="row">RHEL 6 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/rhel60_64.box</td>
-    <td>576MB</td>
+    <th scope="row">Puppetlabs CentOS 5.8 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-58-x64.box</td>
+    <td>587MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Puppetlabs CentOS 6.3 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-63-x64.box</td>
+    <td>530MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Puppetlabs Debian 6.0.6 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-606-x64.box</td>
+    <td>268MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Puppetlabs SLES 11sp1 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64.box</td>
+    <td>504MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Puppetlabs Ubuntu 1004 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1004-x64.box</td>
+    <td>335MB</td>
+  </tr>
+  <tr>
+    <th scope="row">Puppetlabs Ubuntu 1204 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+    <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box</td>
+    <td>418MB</td>
   </tr>
   <tr>
     <th scope="row">Scientific Linux 6 64 chefclient0.10</th>
@@ -353,11 +363,6 @@
     <th scope="row">Slackware 13.37</th>
     <td>http://dl.dropbox.com/u/10544201/slackware-13.37.box</td>
     <td>2200MB</td>
-  </tr>
-  <tr>
-    <th scope="row">SLES 11sp1 64 puppet</th>
-    <td>http://puppetlabs.s3.amazonaws.com/pub/sles11sp1_64.box</td>
-    <td>665MB</td>
   </tr>
   <tr>
     <th scope="row">Ubuntu 10.04.4 LTS Lucid x86_64 (Apache 2.2.14, PHP 5.3.2, MySQL 5.1.66)</th>


### PR DESCRIPTION
The puppetlabs boxes were old and no longer maintained and probably not to be
relied on any more. This patch points to our new vagrant boxes.

Signed-off-by: Ken Barber ken@bob.sh
