### PR TITLE
Note missing guest additions on official Ubuntu boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -250,32 +250,32 @@
     <td>362MB</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (Guest Additions)</th>
+    <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-amd64-disk1.box</td>
     <td>258M</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (Guest Additions)</th>
+    <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-i386-disk1.box</td>
     <td>258M</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 12.10 daily Cloud Image amd64 (Guest Additions)</th>
+    <th scope="row">Official Ubuntu 12.10 daily Cloud Image amd64 (No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/quantal/current/quantal-server-cloudimg-vagrant-amd64-disk1.box</td>
     <td>258M</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 12.10 daily Cloud Image i386 (Guest Additions)</th>
+    <th scope="row">Official Ubuntu 12.10 daily Cloud Image i386 (No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/quantal/current/quantal-server-cloudimg-vagrant-i386-disk1.box</td>
     <td>258M</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 13.04 daily Cloud Image amd64 (Development release, Guest Additions)</th>
+    <th scope="row">Official Ubuntu 13.04 daily Cloud Image amd64 (Development release, No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/raring/current/raring-server-cloudimg-vagrant-amd64-disk1.box</td>
     <td>257M</td>
   </tr>
   <tr>
-    <th scope="row">Official Ubuntu 13.04 daily Cloud Image i386 (Development release, Guest Additions)</th>
+    <th scope="row">Official Ubuntu 13.04 daily Cloud Image i386 (Development release, No Guest Additions)</th>
     <td>http://cloud-images.ubuntu.com/raring/current/raring-server-cloudimg-vagrant-i386-disk1.box</td>
     <td>257M</td>
   </tr>


### PR DESCRIPTION
The boxes provided at cloud-images.ubuntu.com are not packaged with guest additions. Current link headlines are a bit misleading.
