### PR TITLE
Use expanded URL so we know where it goes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -186,7 +186,7 @@
   </tr>
   <tr>
     <th scope="row">Debian Squeeze amd64 (with Puppet, Chef and VirtualBox 4.2.1)</th>
-    <td>http://goo.gl/2H6Fo</td>
+    <td>http://f.willianfernandes.com.br/vagrant-boxes/DebianSqueeze64.box</td>
     <td>272MB</td>
   </tr>
   <tr>


### PR DESCRIPTION
http://goo.gl/2H6Fo redirects to http://f.willianfernandes.com.br/vagrant-boxes/DebianSqueeze64.box

Before adding the box, I wanted to get a better sense of what it would be adding.  I'm sure I'm not the only one that would be interested in this.  :smile:

Thanks for making vagrantbox.es!

Ben
