### PR TITLE
Added links to AppScale vagrant boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -45,7 +45,7 @@
  <span>$ </span>vagrant up
 </pre>
 
-<p>The list of boxes was last updated on January 19, 2013.</p>
+<p>The list of boxes was last updated on February 24, 2013.</p>
 
 <p><b>NEW</b>: Table is sortable by clicking on the column headers.</p>
 
@@ -68,6 +68,16 @@
     <th scope="row">Aegir-up LAMP (Debian Stable 64-bit)</th>
     <td>http://ergonlogic.com/files/boxes/debian-LAMP-current.box</td>
     <td>388MB</td>
+  </tr>
+   <tr>
+    <th scope="row">AppScale 1.6.6 (Ubuntu Lucid 64-bit)</th>
+    <td>http://download.appscale.com/download/AppScale%201.6.6%20VirtualBox%20Image</td>
+    <td>2000 MB</td>
+  </tr>
+  <tr>
+    <th scope="row">AppScale 1.6.7 (Ubuntu Lucid 64-bit)</th>
+    <td>http://download.appscale.com/download/AppScale%201.6.7%20VirtualBox%20Image</td>
+    <td>2000 MB</td>
   </tr>
   <tr>
     <th scope="row">Arch Linux 64 (2012-07-02)</th>


### PR DESCRIPTION
AppScale is an open source implementation of the Google App Engine APIs. For each of our releases, we release a VirtualBox image that can be imported and used with vagrant. This pull request adds links to the two most recently released VirtualBox images (in .box format). These images are pre-built from a base Lucid 64-bit image, and come with HBase, Hypertable, and Cassandra pre-installed.
