### PR TITLE
Add updated CentOS 6.4 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -130,11 +130,6 @@
     <td>651MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 6.3 i386 Minimal (VirtualBox Guest Additions 4.2.6, Chef 10.16.4, Puppet 3.0.2)</th>
-    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-i386-v20130101.box</td>
-    <td>386MB</td>
-  </tr>
-  <tr>
     <th scope="row">CentOS 6.3 x86_64 + Chef 10.14.2 + VirtualBox 4.1.22 (with guest additions)</th>
     <td>https://s3.amazonaws.com/itmat-public/centos-6.3-chef-10.14.2.box</td>
     <td>445MB</td>
@@ -145,9 +140,14 @@
     <td>310MB</td>
   </tr>
   <tr>
-    <th scope="row">CentOS 6.3 x86_64 Minimal (VirtualBox Guest Additions 4.2.6, Chef 10.16.4, Puppet 3.0.2)</th>
-    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.3-x86_64-v20130101.box</td>
-    <td>455MB</td>
+    <th scope="row">CentOS 6.4 i386 Minimal (VirtualBox Guest Additions 4.2.8, Chef 11.4.0, Puppet 3.1.0)</th>
+    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-i386-v20130309.box</td>
+    <td>398MB</td>
+  </tr>
+  <tr>
+    <th scope="row">CentOS 6.4 x86_64 Minimal (VirtualBox Guest Additions 4.2.8, Chef 11.4.0, Puppet 3.1.0)</th>
+    <td>http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-x86_64-v20130309.box</td>
+    <td>469MB</td>
   </tr>
   <tr>
     <th scope="row">Debian 6 Squeeze x64 configured according to documentation</th>


### PR DESCRIPTION
New CentOS 6.4 boxes with the latest dependencies (VirtualBox Guest Additions 4.2.8, Chef 11.4.0, Puppet 3.1.0).
