### PR TITLE
new squeeze64 base box for vmware fusion provider

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -162,6 +162,11 @@
     <td>408MB</td>
   </tr>
   <tr>
+    <th scope="row">Debian 6 Squeeze x64 (VMware Fusion provider) configured according to documentation (<a href="https://github.com/jousch/vagrant-basebox-debian_squeeze64-vmware/blob/master/README.md">More Details</a>)</th>
+    <td>https://dl.dropbox.com/u/39133545/Publish/Vagrant/Provider/Vmware/vagrant-debian-squeeze64.box</td>
+    <td>334.9MB</td>
+  </tr>
+  <tr>
     <th scope="row">Debian Lenny 32</th>
     <td>https://s3-eu-west-1.amazonaws.com/glassesdirect-boxen/debian/debian_lenny_32.box</td>
     <td>351MB</td>


### PR DESCRIPTION
Adds link to my new base box debian squeeze64 for vagrant with custom provider vmware_fusion
