### PR TITLE
Update Fedora 18 x86 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -255,10 +255,10 @@
         </tr>
         <tr>
           <th scope="row">Fedora 18 x86 Minimal (with Chef 11.4.0, VirtualBox Guest Additions 4.2.10 and rpmfusion enabled);<br>
-            md5sum 7596c557370184d332b65dec06aaa065<br>
-            sha1sum d50c4826d6687034e2817a6d565430d415c9c0c8</th>
-          <td>http://static.stasiak.at/fedora-18-x86-1.box</td>
-          <td>559MB</td>
+            md5sum 36b8aaf49421510a726b6175ee44e15b<br>
+            sha1sum d5a6a3c4ab1538105b18e6efba4d9479798a430e</th>
+          <td>http://static.stasiak.at/fedora-18-x86-2.box</td>
+          <td>635MB</td>
         </tr>
         <tr>
           <th scope="row">FreeBSD 9.1 amd64 - UFS (<a href="https://github.com/xironix/freebsd-vagrant/blob/master/README.md">src</a>)</th>


### PR DESCRIPTION
Previous version didn't have NFS utils installed and had guest additions 4.2.8 instead of advertised 4.2.10.
