### PR TITLE
Refresh of Puppetlabs boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -366,34 +366,84 @@
           <td>603MB</td>
         </tr>
         <tr>
-          <th scope="row">Puppetlabs CentOS 5.8 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-58-x64.box</td>
-          <td>587MB</td>
-        </tr>
-        <tr>
-          <th scope="row">Puppetlabs CentOS 6.3 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-63-x64.box</td>
+          <th scope="row">Puppetlabs CentOS 5.9 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210.box</td>
           <td>530MB</td>
         </tr>
         <tr>
-          <th scope="row">Puppetlabs Debian 6.0.6 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-606-x64.box</td>
-          <td>268MB</td>
+          <th scope="row">Puppetlabs CentOS 5.9 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210-nocm.box</td>
+          <td>522MB</td>
         </tr>
         <tr>
-          <th scope="row">Puppetlabs SLES 11sp1 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64.box</td>
-          <td>504MB</td>
+          <th scope="row">Puppetlabs CentOS 6.4 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210.box</td>
+          <td>523MB</td>
         </tr>
         <tr>
-          <th scope="row">Puppetlabs Ubuntu 1004 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1004-x64.box</td>
-          <td>335MB</td>
+          <th scope="row">Puppetlabs CentOS 6.4 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box</td>
+          <td>521MB</td>
         </tr>
         <tr>
-          <th scope="row">Puppetlabs Ubuntu 1204 x86_64 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
-          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box</td>
-          <td>418MB</td>
+          <th scope="row">Puppetlabs Debian 6.0.7 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210.box</td>
+          <td>271MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Debian 6.0.7 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210-nocm.box</td>
+          <td>249MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Debian 7.0rc1 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-70rc1-x64-vbox4210.box</td>
+          <td>302MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Debian 7.0rc1 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/debian-70rc1-x64-vbox4210-nocm.box</td>
+          <td>281MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Fedora 18 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/fedora-18-x64-vbox4210.box</td>
+          <td>596MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Fedora 18 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/fedora-18-x64-vbox4210-nocm.box</td>
+          <td>611MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs SLES 11sp1 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210.box</td>
+          <td>519MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs SLES 11sp1 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210-nocm.box</td>
+          <td>500MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Ubuntu 10.04.4 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box</td>
+          <td>323MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Ubuntu 10.04.4 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box</td>
+          <td>313MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Ubuntu 12.04.2 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64-vbox4210.box</td>
+          <td>400MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Puppetlabs Ubuntu 12.04.2 x86_64, VBox 4.2.10, No Puppet or Chef (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
+          <td>http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64-vbox4210-nocm.box</td>
+          <td>352MB</td>
         </tr>
         <tr>
           <th scope="row">Scientific Linux 6 64 chefclient0.10</th>


### PR DESCRIPTION
Rebuilt with VBox 4.2.10 guest extensions.

Added Fedora 18 and Debian 7.0rc1 as well, plus nocm variants.

Signed-off-by: Ken Barber ken@bob.sh
