### PR TITLE
vagrant-Cent6.4-PHPDev-x86_64-vmware_fusion

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -204,6 +204,11 @@
           <td>545.94MB</td>
         </tr>
         <tr>
+          <th scope="row">CentOS 6.4 x86_64 VMware Fusion (VMware Tools, Chef, Puppet, Percona5.5, MailCatcher, PHP5.3 & PHP5.4, Nginx, phpMyAdmin)</th>
+          <td>https://dl.dropboxusercontent.com/u/4270686/VagrantBoxes/vagrant-Cent6.4-PHPDev-x86_64-vmware_fusion.box</td>
+          <td>1100MB</td>
+        </tr>        
+        <tr>
           <th scope="row">Debian 6 Squeeze x64 configured according to documentation</th>
           <td>http://www.emken.biz/vagrant-boxes/debsqueeze64.box</td>
           <td>408MB</td>


### PR DESCRIPTION
This is a Cent 6.4 x86_64 minimal install for the new VMware Fusion provider with the addition of the latest stable Nginx, PHP-FPM 5.3 and 5.4. It also includes phpMyAdmin and Mailcatcher. Percona 5.5 is installed. The idea is to give a reasonable PHP DEV box with a quick boot time, the image is slightly larger than I wanted, but, boot time is around 20 seconds on my iMac. Chef and Puppet are also configured. It runs fine in 512MB of RAM. 

If you create a file 'php54' in your project directory (/vagrant) and restart 'service php-fpm restart' you can switch between PHP5.3 and PHP5.4 easily. Both versions use the same php.ini file and have the same './configure' line.
