### PR TITLE
Update URLs for Self-Hosting

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -497,12 +497,12 @@
         </tr>
         <tr>
           <th scope="row">Ubuntu 12.04.2 Server i386 with VirtualBox Guest Additions v4.2.6, Chef Omnibus 11</th>
-          <td>https://s3.amazonaws.com/gsc-vagrant-boxes/ubuntu-12.04.2-i386-chef-11-omnibus.box</td>
+          <td>http://grahamc.com/vagrant/ubuntu-12.04.2-i386-chef-11-omnibus.box</td>
           <td>428M</td>
         </tr>
         <tr>
           <th scope="row">Ubuntu 12.04.2 Server amd64 for VMWare Fusion and Chef Omnibus 11</th>
-          <td>https://s3.amazonaws.com/gsc-vagrant-boxes/ubuntu-12.04.2-server-amd64.box</td>
+          <td>http://grahamc.com/vagrant/ubuntu-12.04.2-server-amd64-vmware-fusion.box</td>
           <td>446M</td>
         </tr>
         <tr>
@@ -576,7 +576,7 @@
           <td>389MB</td>
         </tr>
         <th scope="row">Ubuntu 12.04.2 AMD64 (Chef 11 installed via Omnibus; VirtualBox 4.2.6; Standard Puppet)</th>
-        <td>https://s3.amazonaws.com/gsc-vagrant-boxes/ubuntu-12.04-omnibus-chef.box</td>
+        <td>http://grahamc.com/vagrant/ubuntu-12.04-omnibus-chef.box</td>
         <td>372M</td>
       </tr>
       <tr>


### PR DESCRIPTION
Tragically hosting these on AWS are straight-up too expensive.

Moving them to my own servers with their massive reserves of free
bandwidth will make it possible to keep hosting them.

Additionally, it appears the vmware-fusion box wasn't properly linked.

If you need any sort of verification, let me know how I can. Note: The old files will remain there on AWS, but preventing future people from finding them there would be helpful.
