### PR TITLE
Vagrant box with database cluster deployments scripts

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -461,6 +461,11 @@
           <td>376M</td>
         </tr>
         <tr>
+          <th scope="row">Severalnines ClusterControl, Database Cluster Deployment Scripts, VBox 4.2.10, Ubuntu 12.04 LTS (<a href="http://www.alexyu.se/content/2013/03/vagrant-box-severalnines-database-cluster-deployment-scripts">How-to</a>)</th>
+          <td>https://googledrive.com/host/0B-J3zLLFd9HMLUhkckZBWi1xVlE/s9s_clustercontrol.box</td>
+          <td>390MB</td>
+        </tr>
+        <tr>
           <th scope="row">Slackware 13.37</th>
           <td>http://dl.dropbox.com/u/10544201/slackware-13.37.box</td>
           <td>2200MB</td>


### PR DESCRIPTION
Hi, 
This is an Ubuntu vagrant box with deployment scripts for setting up a database cluster (cluster with multiple vbox instances) using mongodb, MySQL Cluster, Galera Cluster for MySQL or Replication. It also comes with Severalnines ClusterControl for Monitoring and Management of database cluster. 
