### PR TITLE
Append Debian Wheezy amd64 Vanilla

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -244,6 +244,11 @@
           <td>496.78MB</td>
         </tr>
         <tr>
+          <th scope="row">Debian Wheezy 7.0 amd64 - Vanilla (No Ruby, no puppet, no Chef)</th>
+          <td>https://dl.dropboxusercontent.com/s/xymcvez85i29lym/vagrant-debian-wheezy64.box</td>
+          <td>242MB</td>
+        </tr>
+        <tr>
           <th scope="row">Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6)</th>
           <td>http://dl.dropbox.com/u/6002490/vagrant/beefymiracle32.box</td>
           <td>804.25MB</td>


### PR DESCRIPTION
Debian Wheezy 7.0 amd64 - Vanilla (No Ruby, no puppet, no Chef)

https://dl.dropboxusercontent.com/s/xymcvez85i29lym/vagrant-debian-wheezy64.box
