### PR TITLE
added Debian 7.0 Wheezy boxes, released on May 4th, 2013

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -99,17 +99,17 @@
       </thead>
       <tbody>
         <tr>
-          <th scope="row">Aegir-up Aegir (Debian Stable 64-bit)  </th>
+          <th scope="row">Aegir-up Aegir (Debian Squeeze 6.0.4 64-bit)  </th>
           <td>http://ergonlogic.com/files/boxes/aegir-current.box</td>
           <td>297MB</td>
         </tr>
         <tr>
-          <th scope="row">Aegir-up Debian (Stable 64-bit)</th>
+          <th scope="row">Aegir-up Debian (Debian Squeeze 6.0.4 64-bit)</th>
           <td>http://ergonlogic.com/files/boxes/debian-current.box</td>
           <td>283MB</td>
         </tr>
         <tr>
-          <th scope="row">Aegir-up LAMP (Debian Stable 64-bit)</th>
+          <th scope="row">Aegir-up LAMP (Debian Squeeze 6.0.4 64-bit)</th>
           <td>http://ergonlogic.com/files/boxes/debian-LAMP-current.box</td>
           <td>388MB</td>
         </tr>
@@ -252,6 +252,16 @@
           <th scope="row">Debian Squeeze 6.0.7 amd64 (french) with Puppet 3.1.1, Chef 11.4.0 and VirtualBox 4.2.12, built with Veewee 0.3.7 (2013/04/20)</th>
           <td>http://public.sphax3d.org/vagrant/squeeze64.box</td>
           <td>294.19MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Debian Wheezy (7.0.0) amd64, no Ruby/Puppet/Chef, VirtualBox 4.2.4, built with Veewee 0.3.7 (2013/06/12) </th>
+          <td>https://www.dropbox.com/s/gxouugzbnjlny1k/debian-7.0-amd64-minimal.box </td>
+          <td>280MB</td>
+        </tr>
+        <tr>
+          <th scope="row">Debian Wheezy (7.0.0) amd64, with Ruby 1.9.1, Puppet 3.2.1, Chef 11.4.4, VirtualBox 4.2.4, built with Veewee 0.3.7 (2013/06/12) </th>
+          <td>https://www.dropbox.com/s/si19tbftilcuipz/debian-7.0-amd64.box </td>
+          <td>302MB</td>
         </tr>
         <tr>
           <th scope="row">Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6)</th>


### PR DESCRIPTION
Boxes were build from debain 7.0 netinstall iso with veewee tool
- Debian Wheezy current stable release http://www.debian.org/News/2013/20130504
- Renamed "Debian Stable" boxes to "Debian Squeeze 6.0.4"
