### PR TITLE
Add a wheezy box 7.1 in 64 bits.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -254,6 +254,11 @@
           <td>294.19MB</td>
         </tr>
         <tr>
+          <th scope="row">Debian Wheezy 7.1 amd64 (french) with Chef 11.4.4 and VirtualBox 4.1.18 (2013/06/19)</th>
+          <td>http://downloads.shadoware.org/wheezy64.box</td>
+          <td>388MB</td>
+        </tr>
+        <tr>
           <th scope="row">Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6)</th>
           <td>http://dl.dropbox.com/u/6002490/vagrant/beefymiracle32.box</td>
           <td>804.25MB</td>


### PR DESCRIPTION
Hi,

I create a wheezy (debian 7.1 with last update) box in 64 bits that work with last version of chef.
