### PR TITLE
Added AppScale 1.8.0 base box to the vagrant box list

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -114,6 +114,11 @@
           <td>388MB</td>
         </tr>
         <tr>
+          <th scope="row">AppScale 1.8.0 (Ubuntu Lucid 64-bit)</th>
+          <td>http://download.appscale.com/apps/AppScale%201.8.0%20VirtualBox%20Image</td>
+          <td>2200 MB</td>
+        </tr>
+        <tr>
           <th scope="row">AppScale 1.6.6 (Ubuntu Lucid 64-bit)</th>
           <td>http://download.appscale.com/download/AppScale%201.6.6%20VirtualBox%20Image</td>
           <td>2000 MB</td>


### PR DESCRIPTION
Requesting the addition of AppScale 1.8.0 base box the list.
