### PR TITLE
Removing broken boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -651,16 +651,6 @@
         <td>https://dl.dropboxusercontent.com/u/165709740/boxes/quantal64-vanilla.box</td>
         <td>389MB</td>
       </tr>
-      <tr>
-        <th scope="row">Windows Server 2008 R2 - Datacentre core (Puppet, VirtualBox 4.2.4)</th>
-        <td>http://dl.dropbox.com/u/58604/vagrant/win2k8r2-core.box</td>
-        <td>1225MB</td>
-      </tr>
-      <tr>
-        <th scope="row">Windows Server 2008 R2 - Datacentre full (Puppet, VirtualBox 4.2.4)</th>
-        <td>http://dl.dropbox.com/u/58604/vagrant/win2k8r2.box </td>
-        <td>3541MB</td>
-      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Removing windows server boxes until newer baseboxes can be created that are compatible with latest vagrant/virtualbox versions.
