### PR TITLE
Removed CentOS 5.5 64 from the list; it 404s when GETing.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -134,11 +134,6 @@
           <td>565MB</td>
         </tr>
         <tr>
-          <th scope="row">CentOS 5.5 64</th>
-          <td>http://dl.dropbox.com/u/15307300/vagrant-0.7-centos-64-base.box</td>
-          <td>499MB</td>
-        </tr>
-        <tr>
           <th scope="row">CentOS 5.6 32</th>
           <td>http://yum.mnxsolutions.com/vagrant/centos_56_32.box</td>
           <td>804MB</td>


### PR DESCRIPTION
This box no longer exists at the given URL, http://dl.dropbox.com/u/15307300/vagrant-0.7-centos-64-base.box
