### PR TITLE
Remove precise64-squishy box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -521,11 +521,6 @@
           <td>568MB</td>
         </tr>
         <tr>
-          <th scope="row">Ubuntu 12.04 LTS x86_64, current as of Feb 9, 2013 (Guest Additions 4.2.6)</th>
-          <td>https://s3-us-west-2.amazonaws.com/squishy.vagrant-boxes/precise64_squishy_2013-02-09.box</td>
-          <td>424M</td>
-        </tr>
-        <tr>
           <th scope="row">Ubuntu 12.04.2 Server i386 with VirtualBox Guest Additions v4.2.6, Chef Omnibus 11</th>
           <td>http://grahamc.com/vagrant/ubuntu-12.04.2-i386-chef-11-omnibus.box</td>
           <td>428M</td>


### PR DESCRIPTION
We no longer use this internally and the URL is broken.
