### PR TITLE
Official Ubuntu 12.04 cloud image contains VBox Additions

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -359,7 +359,7 @@
           <td>443MB</td>
         </tr>
         <tr>
-          <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (No Guest Additions)</th>
+          <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (VirtualBox 4.1.12)</th>
           <td>VirtualBox</td>
           <td>http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-amd64-disk1.box</td>
           <td>341M</td>


### PR DESCRIPTION
Version **4.1.12-dfsg-2ubuntu0.3** of the `virtualbox-guest-dkms` package was discovered in this image.
