### PR TITLE
Official Ubuntu 12.04 cloud image contains VBox Additions

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -383,13 +383,13 @@
           <td>443MB</td>
         </tr>
         <tr>
-          <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (No Guest Additions)</th>
+          <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (VirtualBox 4.1.12)</th>
           <td>VirtualBox</td>
           <td>http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>341M</td>
         </tr>
         <tr>
-          <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (No Guest Additions)</th>
+          <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (VirtualBox 4.1.12)</th>
           <td>VirtualBox</td>
           <td>http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>329M</td>


### PR DESCRIPTION
This seems to have have been removed in the previous merge.

Version `4.1.12-dfsg-2ubuntu0.3` of `virtualbox-guest-dkms` was discovered in these images (I also added this mention for `i386`).
