### PR TITLE
Add debian 7.2 amd64 (with VirtualBox Guest Additions 4.3.0)

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -343,6 +343,12 @@
           <td>388MB</td>
         </tr>
         <tr>
+          <th scope="row">Debian Wheezy 7.2 amd64 (VirtualBox Guest Additions 4.3.0) (2013/10/19)</th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/u/197673519/debian-7.2.0.box</td>
+          <td>295MB</td>
+        </tr>
+        <tr>
           <th scope="row">Fedora 17 i386 (Puppet, Chef, VirtualBox 4.2.6)</th>
           <td>VirtualBox</td>
           <td>http://dl.dropbox.com/u/6002490/vagrant/beefymiracle32.box</td>


### PR DESCRIPTION
Just created a debian amd64 7.2 vagrant box image, it has virtualbox guest additions 4.3.0. 
Verified with vagrant 1.3.5 + virtualbox 4.3.0
