### PR TITLE
Provide updated bitly link to dropbox image

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -538,7 +538,7 @@
         <tr>
           <th scope="row">Ubuntu 12.04 amd64 for with raring kernel and docker 0.6.4</th>
           <td>VirtualBox</td>
-          <td>https://dl.dropbox.com/s/9vmkkmy83g3kzlv/docker-precise64.box</td>
+          <td>http://bit.ly/dockerprecise64</td>
           <td>374M</td>
         </tr>
         <tr>


### PR DESCRIPTION
I have updated the bitly link to the dropbox image.

I planned on bitly because I will be able to upload the image somewhere else (like on S3) and update the bitly link to point to it. (checking with my company if they can host it).
