### PR TITLE
[fgrehm/vagrant-lxc#167] added link to Openmandriva2013.0 vagrant-lxc box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1043,7 +1043,7 @@
         <th scope="row">Openmandriva2013.0 x86_64 (LXC, 2013.10.21)</th>
         <td>Vagrant-LXC</td>
         <td>http://bit.ly/vagrant-lxc-openmandriva2013-0-x86_64-2013-10-21</td>
-        <td>106.17MB</td>
+        <td>88MB</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
See: fgrehm/vagrant-lxc#167
