### PR TITLE
Add FreeBSD 9.2 Minimal box.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -425,7 +425,7 @@
         <tr>
           <th scope="row">FreeBSD 9.2 x86_64 Minimal (VirtualBox, ZFS)</th>
           <td>VirtualBox</td>
-          <td>https://wunki.org/files/freebsd-92-amd64-wunki.box</td>
+          <td>https://wunki.org/files/freebsd-9.2-amd64-wunki.box</td>
           <td>226MB</td>
         </tr>
         <tr>


### PR DESCRIPTION
I created a minimal FreeBSD 9.2. You can view more information in the repository here:

https://github.com/wunki/vagrant-freebsd
