### PR TITLE
Added CentOS 6.4 x86_64 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -247,6 +247,15 @@
           <td>310MB</td>
         </tr>
         <tr>
+          <th scope="row"
+              title="Includes VirtualBox Guest Additions 4.3.0 and standard development tools like gcc, make, etc.">
+                  CentOS 6.4 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases/tag/v0.1.0">notes</a>]
+          </th>
+          <td>VirtualBox</td>
+          <td>https://github.com/2creatives/vagrant-centos/releases/download/v0.1.0/centos64-x86_64-20131030.box</td>
+          <td>301.5 MB</td>
+        </tr>
+        <tr>
           <th scope="row">CentOS 6.4 x86_64 2013-07-01 --  With development tools (gcc, etc...). Works on VBox 4.2.14!</th>
           <td>VirtualBox</td>
           <td>http://shonky.info/centos64.box</td>


### PR DESCRIPTION
This includes no provisioning software but does include
developement tools such as `gcc`, `make`, etc. VirtualBox Guest
Additions 4.3.0 is preinstalled.
