### PR TITLE
Added Gentoo-20131024-amd64, Gentoo-20131029-i686 and minimal baseboxes for VirtualBox 4.3.0

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -450,6 +450,46 @@
           <td>357MB</td>
         </tr>
         <tr>
+          <th scope="row"
+              title="Gentoo for amd64, packaged with 'unicode noX' setting by hyamamoto, includes VirtualBox Guest Additions 4.3, chef-10.24.0, and puppet-3.3.1">
+                  Gentoo 2013.10.24 amd64 (chef, puppet) on 2013.10.30
+                  [<a href="https://github.com/hyamamoto/gentoo-bento-boxes">src</a>]
+          </th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/s/qubuaqiizvfpsyx/gentoo-20131024-amd64.box</td>
+          <td>416.4 MB</td>
+        </tr>
+        <tr>
+          <th scope="row"
+              title="Gentoo for amd64, packaged with 'unicode noman noinfo nodoc noX' setting by hyamamoto, includes VirtualBox Guest Additions 4.3">
+                  Gentoo 2013.10.24 amd64 minimal on 2013.10.30
+                  [<a href="https://github.com/hyamamoto/gentoo-bento-boxes">src</a>]
+          </th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/s/mfurnvstqoj8w47/gentoo-20131024-amd64-minimal.box</td>
+          <td>279.7 MB</td>
+        </tr>
+        <tr>
+          <th scope="row"
+              title="Gentoo for i686, packaged with 'unicode noX' setting by hyamamoto, includes VirtualBox Guest Additions 4.3, chef-10.24.0, and puppet-3.3.1">
+                  Gentoo 2013.10.29 i686 (chef, puppet) on 2013.10.30
+                  [<a href="https://github.com/hyamamoto/gentoo-bento-boxes">src</a>]
+          </th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/s/xfl63k64zliixid/gentoo-20131029-i686.box</td>
+          <td>413.1 MB</td>
+        </tr>
+        <tr>
+          <th scope="row"
+              title="Gentoo boxfor i686, packaged with 'unicode noman noinfo nodoc noX' setting by hyamamoto, includes VirtualBox Guest Additions 4.3">
+                  Gentoo 2013.10.29 amd64 minimal on 2013.10.30
+                  [<a href="https://github.com/hyamamoto/gentoo-bento-boxes">src</a>]
+          </th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/s/0e23qmbo97wb5x2/gentoo-20131029-i686-minimal.box</td>
+          <td>266.2 MB</td>
+        </tr>
+        <tr>
           <th scope="row">Funtoo 2013.06 amd64 (Chef omnibus 11.4.4, VirtualBox 4.2.12)</th>
           <td>VirtualBox</td>
           <td>https://lxmx-vm.s3.amazonaws.com/vagrant/boxes/lxmx_funtoo-2013.06_chef-11.4.4.box</td>


### PR DESCRIPTION
I added the latest Gentoo boxes for VirtualBox 4.3.0. These box are basically built from [veewee template](https://github.com/jedi4ever/veewee/pull/830) which I updated recently. 

Plains
- Gentoo 2013.10.24 amd64 (chef, puppet) on 2013.10.30 - 416.4 MB
- Gentoo 2013.10.29 i686 (chef, puppet) on 2013.10.30 - 413.1 MB
  - packaged with 'unicode noX' setting
  - VirtualBox Guest Additions 4.3
  - portage emptied
  - chef-10.24.0, and puppet-3.3.1

Minimals
- Gentoo 2013.10.24 amd64 minimal on 2013.10.30 - 279.7 MB
- Gentoo 2013.10.29 i686 minimal on 2013.10.30 - 266.2 MB
  - packaged with 'unicode noman noinfo nodoc noX' setting
  - no kernel sources
  - portage emptied
  - VirtualBox Guest Additions 4.3
