### PR TITLE
Add Windows 7 Enterprise Edition

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -473,6 +473,12 @@
           <td>2346MB</td>
         </tr>
         <tr>
+          <th scope="row">Microsoft Windows 7 Enterprise Edition (32-bit)</th>
+          <td>VirtualBox</td>
+          <td>http://vagrantboxes.devopslive.org/windows-7-enterprise-i386.box</td>
+          <td>2839MB</td>
+        </tr>
+        <tr>
           <th scope="row">Minimal CentOS 5.6</th>
           <td>VirtualBox</td>
           <td>http://dl.dropbox.com/u/9227672/centos-5.6-x86_64-netinstall-4.1.6.box</td>


### PR DESCRIPTION
More details about this box can be found here https://gist.github.com/johnjelinek/7299099. This box is a trial version of Windows 7 Enterprise Edition. The host regenerates the box daily so the link never expires.
