### PR TITLE
Update of AppScale distribution to most current release

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -129,9 +129,9 @@
           <td>388MB</td>
         </tr>
         <tr>
-          <th scope="row">AppScale 1.11.0 (Ubuntu Lucid 64-bit)</th>
+          <th scope="row">AppScale 1.12.0 (Ubuntu Precise 12.04 64-bit)</th>
           <td>VirtualBox</td>
-          <td>http://download.appscale.com/download/AppScale%201.11.0%20VirtualBox%20Lucid%20Image</td>
+          <td>http://download.appscale.com/download/AppScale%201.12.0%20VirtualBox%20Image</td>
           <td>1900 MB</td>
         </tr>
         <tr>


### PR DESCRIPTION
Replaced AppScale v1.11.0 with current version 1.12.0
