### PR TITLE
Add CentOS 6.5 LXC image

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -280,6 +280,18 @@
           <td>545.94MB</td>
         </tr>
         <tr>
+          <th scope="row">CentOS 6.4 amd64 for vagrant-lxc with Puppet 3.3.1</th>
+          <td>Vagrant-LXC</td>
+          <td>https://dl.dropboxusercontent.com/s/eukkxp5mp2l5h53/lxc-centos6.4-2013-10-24.box</td>
+          <td>251M</td>
+        </tr>
+        <tr>
+          <th scope="row">CentOS 6.5 amd64 for vagrant-lxc with Puppet 3.3.2</th>
+          <td>Vagrant-LXC</td>
+          <td>https://dl.dropboxusercontent.com/s/x1085661891dhkz/lxc-centos6.5-2013-12-02.box</td>
+          <td>435M</td>
+        </tr>
+        <tr>
           <th scope="row">Debian 6 Squeeze x64 configured according to documentation</th>
           <td>VirtualBox</td>
           <td>http://www.emken.biz/vagrant-boxes/debsqueeze64.box</td>
@@ -589,12 +601,6 @@
           <td>Vagrant-LXC</td>
           <td>http://dl.dropbox.com/u/13510779/lxc-precise-amd64-2013-07-12.box</td>
           <td>94M</td>
-        </tr>
-        <tr>
-          <th scope="row">CentOS 6.4 amd64 for vagrant-lxc with Puppet 3.3.1</th>
-          <td>Vagrant-LXC</td>
-          <td>https://dl.dropboxusercontent.com/s/eukkxp5mp2l5h53/lxc-centos6.4-2013-10-24.box</td>
-          <td>251M</td>
         </tr>
         <tr>
           <th scope="row">Ubuntu 12.04 amd64 for with raring kernel and docker 0.6.4</th>


### PR DESCRIPTION
Update to new CentOS release for Vagrant lxc
