### PR TITLE
Added CentOS 6.5 x86_64 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -91,7 +91,7 @@
  <span>$ </span>vagrant up
 </pre>
 
-    <p>The list of boxes was last updated on 2 December 2013.</p>
+    <p>The list of boxes was last updated on 5 December 2013.</p>
 
     <table class="sortable">
       <thead>
@@ -276,11 +276,11 @@
         <tr>
           <th scope="row"
               title="Includes VirtualBox Guest Additions 4.3.4 and standard development tools like gcc, make, etc.">
-                  CentOS 6.5 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases/tag/v6.5.0">notes</a>]
+                  CentOS 6.5 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases/tag/v6.5.1">notes</a>]
           </th>
           <td>VirtualBox</td>
-          <td>https://github.com/2creatives/vagrant-centos/releases/download/v6.5.0/centos65-x86_64-20131202.box</td>
-          <td>314.6 MiB</td>
+          <td>https://github.com/2creatives/vagrant-centos/releases/download/v6.5.1/centos65-x86_64-20131205.box</td>
+          <td>271.2 MiB</td>
         </tr>
         <tr>
           <th scope="row">Debian 6 Squeeze x64 configured according to documentation</th>


### PR DESCRIPTION
This includes no provisioning software but does include
development tools such as gcc, make, etc. VirtualBox Guest
Additions 4.3.4 is preinstalled.
