### PR TITLE
Added Oracle Linux 5.10 & 6.5 x86_64 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -723,6 +723,12 @@
           <td>509MB</td>
         </tr>
         <tr>
+          <th scope="row">Oracle Linux 6.5 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-6-x86_64.md">src</a>)</th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropbox.com/s/613uhl43ekqzami/oraclelinux-6-x86_64.box</td>
+          <td>684MB</td>
+        </tr>
+        <tr>
           <th scope="row">Puppetlabs CentOS 5.9 x86_64, VBox 4.2.10 (<a href="http://github.com/puppetlabs/puppet-vagrant-boxes">src</a>)</th>
           <td>VirtualBox</td>
           <td>http://puppet-vagrant-boxes.puppetlabs.com/centos-59-x64-vbox4210.box</td>


### PR DESCRIPTION
Added the following 2 updated boxes due to the new releases
- Oracle Linux 5.10 x86_64
- Oracle Linux 6.5 x86_64

Start to use the new naming scheme (`<OS name>-<version>-<architecture>`) for `.box` files and their [sources](https://github.com/terrywang/vagrantboxes).

Please merge;-)
