### PR TITLE
Add precise64 / Parallels Desktop box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1118,6 +1118,12 @@
         <td>http://bit.ly/vagrant-lxc-openmandriva2013-0-x86_64-2013-10-21</td>
         <td>88MB</td>
       </tr>
+      <tr>
+        <th scope="row">Ubuntu Server Precise 12.04.3 amd64<br>(ruby, puppet, Parallels Tools)<br>For use with Parallels 9 + <a href="https://github.com/yshahin/vagrant-parallels">vagrant-parallels</a>.</th>
+        <td>Parallels</td>
+        <td>https://www.dropbox.com/s/of3ekvgk7riux8f/prls9-precise64.box</td>
+        <td>493.3MB</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Add a simple Ubuntu preicse64 box made with Parallels 9 to be used with the [vagrant-parallels](https://github.com/yshahin/vagrant-parallels) plugin.
