### PR TITLE
Remove unusable Dropbox link for "CentOS 6.3 x86_64 minimal"

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -247,12 +247,6 @@
           <td>445MB</td>
         </tr>
         <tr>
-          <th scope="row">CentOS 6.3 x86_64 minimal</th>
-          <td>VirtualBox</td>
-          <td>https://dl.dropbox.com/u/7225008/Vagrant/CentOS-6.3-x86_64-minimal.box</td>
-          <td>310MB</td>
-        </tr>
-        <tr>
           <th scope="row"
               title="Includes VirtualBox Guest Additions 4.3.0 and standard development tools like gcc, make, etc.">
                   CentOS 6.4 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases/tag/v0.1.0">notes</a>]


### PR DESCRIPTION
When trying to use it, it returns a "509 Bandwdith error".
