### PR TITLE
Centos 6.5 vagrant - with puppet 3.3.2

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -296,7 +296,7 @@
         </tr>
         <tr>
           <th scope="row"
-              title="Includes Puppet, VirtualBox Guest Additions 4.3.4, standard development tools like gcc, make, etc.">
+              title="Includes Puppet 3.3.2, VirtualBox Guest Additions 4.3.4, standard development tools like gcc, make, etc.">
                   CentOS 6.5 x86_64 [Built on top of <a href="https://github.com/2creatives/vagrant-centos/releases/download/v6.5.1/centos65-x86_64-20131205.box">creatives box</a>]
 
           </th>


### PR DESCRIPTION
Adding a Centos 6.5 (x86_64) box with puppet 3.3.2
