### PR TITLE
Added a CentOS 6.5 i386 minimal box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -291,7 +291,7 @@
                   CentOS 6.5 i386 Minimal [<a href="https://github.com/Label305/vagrant-centos/releases/tag/v6.5">notes</a>]
           </th>
           <td>VirtualBox</td>
-          <td>https://github.com/Label305/vagrant-centos/releases/download/v6.5/centos65-i368-minimal-20131230.box</td>
+          <td>https://github.com/label305/vagrant-centos/releases/download/v6.5/centos65-i386-minimal-20131230.box</td>
           <td>544.3 MB</td>
         </tr>
         <tr>


### PR DESCRIPTION
This box comes without any provisioning software beyond the shell but it does include development tools such as gcc, make, etc. VirtualBox Guest Additions 4.3.6 has also been installed.

Tested with Vagrant 1.4.1 and VirtualBox 4.3.6 on a OS X 10.9.1 host machine.
