### PR TITLE
Add Fedora 19 with Salt & NFS client

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -453,6 +453,12 @@
           <td>400MB</td>
         </tr>
         <tr>
+          <th scope="row">Fedora 19 x86_64 (Puppet, Salt, VirtualBox, NFS client)</th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/u/253044069/fedora-19.box</td>
+          <td>456MB</td>
+        </tr>
+        <tr>
           <th scope="row">FreeBSD 9.2 x86_64 Minimal (VirtualBox, ZFS)</th>
           <td>VirtualBox</td>
           <td>https://wunki.org/files/freebsd-9.2-amd64-wunki.box</td>


### PR DESCRIPTION
based on the existing Fedora 19 box, this one have Salt and NFS clients preinstalled
