### PR TITLE
Added Ubuntu precise64 box with puppetlabs repo

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -980,6 +980,12 @@
           <td>323MB</td>
         </tr>
         <tr>
+          <th scope="row">Ubuntu precise 64 VirtualBox with puppetlabs release apt repo and corresponding puppet versions</th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/s/8u4u4yslowzc4y6/precise64-puppetlabs-release-precise.box</td>
+          <td>299 MB</td>
+        </tr>
+        <tr>
             <th scope="row">Ubuntu precise 64 VMWare</th>
             <td>VMware</td>
             <td>http://files.vagrantup.com/precise64_vmware.box</td>


### PR DESCRIPTION
Added box with release apt repo from puppet labs. Curremtly installed puppet version is 3.4.
