### PR TITLE
removed unavailable box squeeze64

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -355,12 +355,6 @@
           <td>496.78MB</td>
         </tr>
         <tr>
-          <th scope="row">Debian Squeeze 6.0.7 amd64 (french) with Puppet 3.1.1, Chef 11.4.0 and VirtualBox 4.2.12, built with Veewee 0.3.7 (2013/04/20)</th>
-          <td>VirtualBox</td>
-          <td>http://public.sphax3d.org/vagrant/squeeze64.box</td>
-          <td>294.19MB</td>
-        </tr>
-        <tr>
           <th scope="row">Debian Squeeze 6.0.8 amd64 (Chef 11.8.0, VMware tools)</th>
           <td>VMware</td>
           <td>http://shopify-vagrant.s3.amazonaws.com/debian-6.0.8_vmware.box</td>


### PR DESCRIPTION
Reason:

```
$ host public.sphax3d.org
Host public.sphax3d.org not found: 3(NXDOMAIN)
```
