### PR TITLE
Added wheezy i386 minimal english box with guest additions.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -439,6 +439,12 @@
           <td>188MB</td>
         </tr>
         <tr>
+          <th scope="row">Debian Wheezy i386 minimal w/ apache and guest additions (2014/01/21)</th>
+          <td>VirtualBox</td>
+          <td>https://dl.dropboxusercontent.com/u/99151903/wheezy.box</td>
+          <td>509MB</td>
+        </tr>
+        <tr>
           <th scope="row">Fedora 18 x86 Minimal (with Chef 11.4.0, VirtualBox Guest Additions 4.2.10 and rpmfusion enabled);<br>
             md5sum 36b8aaf49421510a726b6175ee44e15b<br>
             sha1sum d5a6a3c4ab1538105b18e6efba4d9479798a430e</th>


### PR DESCRIPTION
As above, I noted that vb.es was missing a wheezy 32 bit box. Hopefully solved by this pull.

tarek : )
