### PR TITLE
removes the Debian Wheezy 7.2 amd64 Open Resty box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -397,12 +397,6 @@
           <td>295MB</td>
         </tr>
         <tr>
-          <th scope="row">Debian Wheezy 7.2 amd64 (VirtualBox Guest Additions 4.3.0, <a href="http://openresty.org/">OpenResty</a> 1.4.3.1) (2013/10/31) (<a href="https://github.com/jiko/OpenResty-Vagrant">src</a>)</th>
-          <td>VirtualBox</td>
-          <td>https://dl.dropboxusercontent.com/s/odnew2tnliqft9o/debian7-openresty.box</td>
-          <td>355MB</td>
-        </tr>
-        <tr>
           <th scope="row">Debian Wheezy 7.0 amd64 (Minimal Install + Puppet)</th>
           <td>VirtualBox</td>
           <td>https://www.dropbox.com/s/23gupgb0xompvkm/Wheezy64.box?dl=1</td>


### PR DESCRIPTION
...as the link to it is dead.
