### PR TITLE
Added ubuntu Saucy 13.10 boxes 

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1118,6 +1118,18 @@
         <td>http://bit.ly/vagrant-lxc-openmandriva2013-0-x86_64-2013-10-21</td>
         <td>88MB</td>
       </tr>
+      <tr>
+        <th scope="row">Ubuntu Server Saucy 13.10 amd64 VMWare fusion. Plain box with docker pre-installed.</th>
+        <td>VMWare</td>
+        <td>https://dl.dropboxusercontent.com/u/263376350/ubuntu1310-vagrant-vmware.box</td>
+        <td>402MB</td>
+      </tr>
+      <tr>
+        <th scope="row">Ubuntu Server Saucy 13.10 amd64 Virtualbox. Plain box with docker pre-installed.</th>
+        <td>Virtualbox</td>
+        <td>https://dl.dropboxusercontent.com/u/263376350/ubuntu1310-vagrant-virtualbox.box</td>
+        <td>359MB</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Adds 2 new boxes
- Ubuntu Saucy 13.10 for VMWare with [docker](http://www.docker.io/) pre-installed.
- Ubuntu Saucy 13.10 for Virtualbox with [docker](http://www.docker.io/) pre-installed.

Boxes have been created using [packer](https://gist.github.com/pulse00/47c6f55d2e5466f7ce7b)
