### PR TITLE
Add Ubuntu 12.04, Ubuntu 13.10 and CentOS 5.6 boxes for vagrant-parallels

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1118,6 +1118,24 @@
         <td>http://bit.ly/vagrant-lxc-openmandriva2013-0-x86_64-2013-10-21</td>
         <td>88MB</td>
       </tr>
+      <tr>
+        <th scope="row">Ubuntu Server Precise 12.04 amd64 (chef, puppet)</th>
+        <td>Parallels</td>
+        <td>http://download.parallels.com/desktop/vagrant/precise64.box</td>
+        <td>499MB</td>
+      </tr>
+      <tr>
+        <th scope="row">Ubuntu Server Saucy 13.10 amd64 (chef, puppet)</th>
+        <td>Parallels</td>
+        <td>http://download.parallels.com/desktop/vagrant/saucy64.box</td>
+        <td>564MB</td>
+      </tr>
+      <tr>
+        <th scope="row">CentOS 6.5 amd64 (chef, puppet)</th>
+        <td>Parallels</td>
+        <td>http://download.parallels.com/desktop/vagrant/centos64.box</td>
+        <td>573MB</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
The boxes were prepared by Veewee, and contain both Chef and Puppet.
As usual, the boxes are not covered by any warranty, expressed or implied.

Vagrant Parallels provider can be downloaded from Parallels github page:
https://github.com/Parallels/vagrant-parallels
