### PR TITLE
Update listed CentOS 6.5 box to latest build

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -287,11 +287,11 @@
         </tr>
         <tr>
           <th scope="row"
-              title="Includes VirtualBox Guest Additions 4.3.4 and standard development tools like gcc, make, etc.">
-                  CentOS 6.5 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases/tag/v6.5.1">notes</a>]
+              title="Includes VirtualBox Guest Additions 4.3.6 and standard development tools like gcc, make, etc.">
+                  CentOS 6.5 x86_64 [<a href="https://github.com/2creatives/vagrant-centos/releases">notes</a>]
           </th>
           <td>VirtualBox</td>
-          <td>https://github.com/2creatives/vagrant-centos/releases/download/v6.5.1/centos65-x86_64-20131205.box</td>
+          <td>https://github.com/2creatives/vagrant-centos/releases/download/v6.5.3/centos65-x86_64-20140116.box</td>
           <td>271.2 MiB</td>
         </tr>
         <tr>


### PR DESCRIPTION
This build of the CentOS 6.5 box fixes issues w/ the vagrant-vbguest plugin.
