### PR TITLE
Remove out-dated Oracle Linux 5.9 & 6.4 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -722,12 +722,6 @@
           <td>367MB</td>
         </tr>
         <tr>
-          <th scope="row">Oracle Linux 5.9 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oracle59.md">src</a>)</th>
-          <td>VirtualBox</td>
-          <td>https://dl.dropbox.com/s/n5o3gfdgjc3ekhl/oracle59.box</td>
-          <td>613MB</td>
-        </tr>
-        <tr>
           <th scope="row">Oracle Linux 5.9 i386 VBox 4.2.16 puppet chef (<a href="https://www.dropbox.com/sh/yim9oyqajopoiqs/UP3csYTGlI/README.txt">src</a>)</th>
           <td>VirtualBox</td>
           <td>https://dl.dropbox.com/sh/yim9oyqajopoiqs/kXejEiEBAO/oracle59-32.box</td>
@@ -744,12 +738,6 @@
           <td>VirtualBox</td>
           <td>https://dl.dropbox.com/s/wsib87iudbzl56a/oraclelinux-5-x86_64.box</td>
           <td>598MB</td>
-        </tr>
-        <tr>
-          <th scope="row">Oracle Linux 6.4 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oracle64.md">src</a>)</th>
-          <td>VirtualBox</td>
-          <td>https://dl.dropbox.com/s/zmitpteca72sjpx/oracle64.box</td>
-          <td>612MB</td>
         </tr>
         <tr>
           <th scope="row">Oracle Linux 6.4 i386 VBox 4.2.16 puppet chef (<a href="https://www.dropbox.com/sh/yim9oyqajopoiqs/UP3csYTGlI/README.txt">src</a>)</th>


### PR DESCRIPTION
Remove out-dated Oracle Linux 5.9 and 6.4 x86_64 base boxes to reduce the traffic generated by shared links under the same Dropbox account.
