### PR TITLE
Add SSL to cloud-images.ubuntu.com

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -709,55 +709,55 @@
         <tr>
           <th scope="row">Official Ubuntu 12.04 daily Cloud Image amd64 (VirtualBox 4.1.12)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>341M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 12.04 daily Cloud Image i386 (VirtualBox 4.1.12)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>329M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 12.10 daily Cloud Image amd64 (No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/quantal/current/quantal-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/quantal/current/quantal-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>298M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 12.10 daily Cloud Image i386 (No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/quantal/current/quantal-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/quantal/current/quantal-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>299M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 13.04 daily Cloud Image amd64 (No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>303M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 13.04 daily Cloud Image i386 (No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/raring/current/raring-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>305M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 13.10 daily Cloud Image amd64 (Development release, No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/saucy/current/saucy-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/saucy/current/saucy-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>309M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 14.04 daily Cloud Image amd64 (Development release, No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box</td>
           <td>362M</td>
         </tr>
         <tr>
           <th scope="row">Official Ubuntu 14.04 daily Cloud Image i386 (Development release, No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>350M</td>
         </tr>
         <tr>
@@ -775,7 +775,7 @@
         <tr>
           <th scope="row">Official Ubuntu 13.10 daily Cloud Image i386 (Development release, No Guest Additions)</th>
           <td>VirtualBox</td>
-          <td>http://cloud-images.ubuntu.com/vagrant/saucy/current/saucy-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/saucy/current/saucy-server-cloudimg-i386-vagrant-disk1.box</td>
           <td>309M</td>
         </tr>
         <tr>


### PR DESCRIPTION
I see no reasen why this URLs doen't use https. I hope there are more URLs in this list, which can used with SSL?
