### PR TITLE
Fix Oracle Linux 5.10 & 6.5 x86_64 boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1048,10 +1048,10 @@
           <td>443MB</td>
         </tr>
         <tr>
-          <th scope="row">Oracle Linux 5.9 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oracle59.md">src</a>)</th>
+          <th scope="row">Oracle Linux 5.10 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-5-x86_64.md">src</a>)</th>
           <td>VirtualBox</td>
-          <td>https://dl.dropbox.com/s/n5o3gfdgjc3ekhl/oracle59.box</td>
-          <td>613MB</td>
+          <td>http://cloud.terry.im/vagrant/oraclelinux-5-x86_64.box</td>
+          <td>599MB</td>
         </tr>
         <tr>
           <th scope="row">Oracle Linux 5.9 i386 VBox 4.2.16 puppet chef (<a href="https://www.dropbox.com/sh/yim9oyqajopoiqs/UP3csYTGlI/README.txt">src</a>)</th>
@@ -1066,10 +1066,10 @@
           <td>445MB</td>
         </tr>
         <tr>
-          <th scope="row">Oracle Linux 6.3 x86_64 (chef) (<a href="https://github.com/terrywang/vagrant/blob/master/oracle64.md">src</a>)</th>
-	  <td>Unknown</td>
-          <td>https://dl.dropbox.com/s/zejz4yljiexqcfu/oracle64.box</td>
-          <td>603MB</td>
+          <th scope="row">Oracle Linux 6.5 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-6-x86_64.md">src</a>)</th>
+          <td>VirtualBox</td>
+          <td>http://cloud.terry.im/vagrant/oraclelinux-6-x86_64.box</td>
+          <td>662MB</td>
         </tr>
         <tr>
           <th scope="row">Oracle Linux 6.4 i386 VBox 4.3.12 puppet chef (<a href="https://sites.google.com/a/stoilis.gr/oracle-linux-vagrant-boxes/home">src</a>)</th>


### PR DESCRIPTION
Just noticed that my Oracle Linux 5.10 and 6.5 x86_64 boxes have been rolled back to 5.9 and 6.3 on [vagrantbox.es](http://vagrantbox.es).

Looks like some recently pull request messed up the `index.html`, someone did NOT do a proper rebase before making changes and sending a pull request.

Fixed now. Boxes have been moved away from Dropbox to dedicated VPS.
