### PR TITLE
Add Oracle Linux 7.0 x86_64 box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1016,6 +1016,13 @@
           <td>662MB</td>
         </tr>
         <tr>
+          <th scope="row">Oracle Linux 7.0 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-7-x86_64.md">src</a>)</th>
+          <td>VirtualBox</td>
+          <td>http://cloud.terry.im/vagrant/oraclelinux-7-x86_64.box</td>
+          <td>552MB</td>
+        </tr>
+        <tr>
+        <tr>
           <th scope="row">Oracle Linux 6.4 i386 VBox 4.3.12 puppet chef (<a href="https://sites.google.com/a/stoilis.gr/oracle-linux-vagrant-boxes/home">src</a>)</th>
 	  <td>VirtualBox</td>
           <td>https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel64-32.box</td>


### PR DESCRIPTION
I've just baked the Oracle Linux 7.0 x86_64 Base Box. Please review and merge;-)

Build information here -> [oraclelinux-7-x86_64.md](https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-7-x86_64.md)
