### PR TITLE
centos65 box with 50G dynamic disk

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -320,6 +320,15 @@
           <td>https://github.com/2creatives/vagrant-centos/releases/download/v6.5.3/centos65-x86_64-20140116.box</td>
           <td>280.0</td>
         </tr>
+	<tr>
+          <td
+              title="Includes VirtualBox Guest Additions 4.3.6, standard development tools and a 50G dynamic disk, for large docker images">
+                  CentOS 6.5 x86_64 with 50G dynamic disk for Docker work. [Built on top of <a href="https://github.com/2creatives/vagrant-centos/releases/download/v6.5.3/centos65-x86_64-20140116.box">creatives box.</a>] [<a href="https://github.com/mrmrcoleman">Maintainer</a>]
+          </td>
+          <td>VirtualBox</td>
+          <td>https://googledrive.com/host/0B4tZlTbOXHYWVGpHRWZuTThGVUE/centos65_virtualbox_50G.box</td>
+          <td>280.0</td>
+        </tr>
         <tr>
           <td
               title="Includes Puppet 3.3.2, VirtualBox Guest Additions 4.3.4, standard development tools like gcc, make, etc.">


### PR DESCRIPTION
"Added centos65 box with 50G dynamic disk as the normal disk gets full REAL fast when working with docker images"

This box is identical to the 2creatives centos65 box but with a 50G dynamic disk. I figured that increasing the disk size manually is sufficiently error prone to warrant a short cut.

Hope you agree!
