### PR TITLE
Fix typo in descriptions for the Phusion boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1465,7 +1465,7 @@
         <td>612</td>
       </tr>
       <tr>
-        <td>Ubuntu Server Precise 14.04 amd64 (<a href="https://github.com/phusion/open-vagrant-boxes">source</a>)
+        <td>Ubuntu Server Trusty 14.04 amd64 (<a href="https://github.com/phusion/open-vagrant-boxes">source</a>)
           <br>
           Kernel is ready for Docker (Docker not included)
           <br>
@@ -1476,7 +1476,7 @@
         <td>547</td>
       </tr>
       <tr>
-        <td>Ubuntu Server Precise 14.04 amd64 (<a href="https://github.com/phusion/open-vagrant-boxes">source</a>)
+        <td>Ubuntu Server Trusty 14.04 amd64 (<a href="https://github.com/phusion/open-vagrant-boxes">source</a>)
           <br>
           Kernel is ready for Docker (Docker not included)
           <br>


### PR DESCRIPTION
As reported by https://github.com/phusion/open-vagrant-boxes/issues/15
