### PR TITLE
Removing my precise64.box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1304,12 +1304,6 @@
           <td>372</td>
         </tr>
         <tr>
-          <td>Ubuntu 12.04.1 LTS x86_64 (Guest Additions 4.1.18)</td>
-          <td>VirtualBox</td>
-          <td>http://dl.dropbox.com/u/1537815/precise64.box</td>
-          <td>568</td>
-        </tr>
-        <tr>
           <td>Ubuntu 12.04.2 Server i386 with VirtualBox Guest Additions v4.2.6, Chef Omnibus 11</td>
           <td>VirtualBox</td>
           <td>http://grahamc.com/vagrant/ubuntu-12.04.2-i386-chef-11-omnibus.box</td>


### PR DESCRIPTION
I'm removing my box for two reasons:
1. It generate too much traffic for Dropbox, hence my public links are constantly disabled,
2. The box is quite old now, it no longer make any sense to use it.
I'll delete the box from my account soon, unless someone wants to host it. If you're interested, add a comment to that PR and I'll transfer it to you.
Thanks.
