### PR TITLE
Update Oracle Linux 5.10 x86_64 base box to 5.11

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1112,10 +1112,10 @@
           <td>443</td>
         </tr>
         <tr>
-          <td>Oracle Linux 5.10 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-5-x86_64.md">src</a>)</td>
+          <td>Oracle Linux 5.11 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-5-x86_64.md">src</a>)</td>
           <td>VirtualBox</td>
           <td>http://cloud.terry.im/vagrant/oraclelinux-5-x86_64.box</td>
-          <td>599</td>
+          <td>637</td>
         </tr>
         <tr>
           <td>Oracle Linux 5.9 x86_64 VBox 4.2.16 puppet chef (<a href="https://sites.google.com/a/stoilis.gr/oracle-linux-vagrant-boxes/home">src</a>)</td>


### PR DESCRIPTION
Updated Oracle Linxu 5.10 x86_64 to 5.11.

Also fixed a problem when starting the vagrant box (VM) without the VirtualBox Extension Pack.

5.11 should be the last minor update for EL 5. End of story ;-D
