### PR TITLE
Added links to Windows Vagrant Boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -1635,7 +1635,7 @@
       <tr>
 	<td>
  	  Windows XP with IE6
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>
+	  <blockquote><p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs.</p> <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-xp-ie6</td>
@@ -1644,7 +1644,7 @@
       <tr>
 	<td>
 	  Windows XP with IE8
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-xp-ie8</td>
@@ -1653,7 +1653,7 @@
       <tr>
 	<td>
 	  Windows Vista with IE7
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>	  	
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>	  	
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-vista-ie7</td>
@@ -1662,7 +1662,7 @@
       <tr>
 	<td>
 	  Windows 7 with IE8
-  	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>
+  	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win7-ie8</td>
@@ -1671,7 +1671,7 @@
       <tr>
 	<td>
 	  Windows 7 with IE9
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win7-ie9</td>
@@ -1680,7 +1680,7 @@
       <tr>
 	<td>
 	  Windows 7 with IE10
-  	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>
+  	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a></strong>.</blockquote>
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win7-ie10</td>
@@ -1689,7 +1689,7 @@
       <tr>
 	<td>
 	  Windows 7 with IE11
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>		
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>		
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win7-ie11</td>
@@ -1698,7 +1698,7 @@
       <tr>
 	<td>
 	  Windows 8 with IE10
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>	
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>	
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win8-ie10</td>
@@ -1707,7 +1707,7 @@
       <tr>
 	<td>
 	  Windows 8.1 with IE11
-	  <p>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. By downloading and using this software, you agree to these license terms.</p>	
+	  <blockquote>The Microsoft Software License Terms for the IE VMs are included in the release notes and supersede any conflicting Windows license terms included in the VMs. <strong>By downloading and using this software, you agree to these <a href="https://modernievirt.blob.core.windows.net/vhd/virtualmachine_instructions_2014-01-21.pdf">license terms</a>.</strong></blockquote>	
 	</td>
 	<td>Virtualbox</td>
 	<td>http://aka.ms/vagrant-win81-ie11</td>


### PR DESCRIPTION
The modern.ie team have created a set of Vagrant boxes for Windows XP, Vista, 7, 8, 8.1 which work with Virtual Box. I've added them to this list. The URLs use [aka.ms](https://aka.ms) which is a Microsoft URL shortening site.

Please send any feedback for the boxes to [@IEDevChat](http://twitter.com/IEDevChat).

Currently they do not support OpenSSH or WinRM, but we would like to get your feedback.
