### PR TITLE
Add official Ubuntu 14.10 daily boxes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -872,6 +872,18 @@
           <td>350</td>
         </tr>
         <tr>
+          <td>Official Ubuntu 14.10 daily Cloud Image amd64 (Development release, No Guest Additions)</td>
+          <td>VirtualBox</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-amd64-vagrant-disk1.box</td>
+          <td>377</td>
+        </tr>
+        <tr>
+          <td>Official Ubuntu 14.10 daily Cloud Image i386 (Development release, No Guest Additions)</td>
+          <td>VirtualBox</td>
+          <td>https://cloud-images.ubuntu.com/vagrant/utopic/current/utopic-server-cloudimg-i386-vagrant-disk1.box</td>
+          <td>376</td>
+        </tr>
+        <tr>
           <td>Ubuntu 13.10 amd64 for VMWare (with Chef, ruby1.9.3 and vmware-tools)</td>
           <td>VMWare</td>
           <td>http://brennovich.s3.amazonaws.com/saucy64_vmware_fusion.box</td>


### PR DESCRIPTION
This pull request adds two new boxes:
- Official Ubuntu 14.10 daily Cloud Image amd64
- Official Ubuntu 14.10 daily Cloud Image i386
