### PR TITLE
Add GovReady CentOS 6.5 pre-hardened box

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -336,6 +336,12 @@
           <td>280.0</td>
         </tr>
         <tr>
+          <td>GovReady&trade; CentOS 6.5 x86_64 pre-hardened FISMA "server" profile. OpenSCAP, SSG, GovReady installed. [<a href="https://github.com/GovReady/govready-centos-6.5-x86_64-noX_server_vagrant">vagrant repo</a>]</td>
+          <td>VirtualBox</td>
+          <td>https://a7240500425256e5d77a-9064bd741f55664f44e550bdad2949f9.ssl.cf5.rackcdn.com/govready-centos-6.5-x86_64-noX-0.2.1-server-0.8.1.box</td>
+          <td>937.9</td>
+        </tr>
+        <tr>
           <td
               title="Includes Puppet 3.3.2, VirtualBox Guest Additions 4.3.4, standard development tools like gcc, make, etc.">
                   CentOS 6.5 x86_64 [Built on top of <a href="https://github.com/2creatives/vagrant-centos/releases/download/v6.5.1/centos65-x86_64-20131205.box">creatives box</a>]


### PR DESCRIPTION
Adding a row/link to pre-hardended for FISMA CentOS 6.5 no-xwindows vagrant box.