### PR TITLE
Smaller box file

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -801,11 +801,11 @@
         <tr>
           <td
               title="Gentoo i686 with systemd, includes VirtualBox Guest Additions 4.3">
-                  Gentoo, built on 2015-02-21, amd64 systemd
+                  Gentoo amd64 with systemd, built 2015-02-22
           </td>
           <td>VirtualBox</td>
-          <td>https://dl.dropboxusercontent.com/u/632007/gentoo-systemd-amd64-virtualbox-2015-02-21.box</td>
-          <td>1600</td>
+          <td>https://dl.dropboxusercontent.com/u/632007/gentoo-systemd-amd64-virtualbox-2015-02-22.box</td>
+          <td>748</td>
         </tr>
         <tr>
           <td>Funtoo 2013.06 amd64 (Chef omnibus 11.4.4, VirtualBox 4.2.12)</td>


### PR DESCRIPTION
Removed lots of unneeded files and zeroed out the partitions before packaging. Less than half the size with no loss of functionality.