### PR TITLE
Update Oracle Linux 7.0 x86_64 base box to 7.1

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1252,13 +1252,13 @@
           <td>Oracle Linux 6.6 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-6-x86_64.md">src</a>)</td>
           <td>VirtualBox</td>
           <td>http://cloud.terry.im/vagrant/oraclelinux-6-x86_64.box</td>
-          <td>662</td>
+          <td>711</td>
         </tr>
         <tr>
-          <td>Oracle Linux 7.0 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-7-x86_64.md">src</a>)</td>
+          <td>Oracle Linux 7.1 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-7-x86_64.md">src</a>)</td>
           <td>VirtualBox</td>
           <td>http://cloud.terry.im/vagrant/oraclelinux-7-x86_64.box</td>
-          <td>552</td>
+          <td>586</td>
         </tr>
         <tr>
           <td>Oracle Linux 6.4 i386 VBox 4.3.12 puppet chef (<a href="https://sites.google.com/a/stoilis.gr/oracle-linux-vagrant-boxes/home">src</a>)</td>


### PR DESCRIPTION
Update Oracle Linux 7.0 x86_64 base box to 7.1.

Updated Oracle Linux 6.6 x86_64 base box size.

EOF