### PR TITLE
Debian Squeeze i386 added

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1858,6 +1858,12 @@
         <td>http://vagrant.t3log.pl/package.box</td>
         <td>670</td>
         </tr>
+      <tr>
+       	<td>Debian Squeeze i386 (bare minimal server for testing)</td>
+        <td>VirtualBox</td>
+        <td>https://pety.dynu.net/cloudbank_repo/debian_squeeze_32bit.box</td>
+        <td>172</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
I did not find a box for testing packages on Debian squeeze 32bit, so created one. It worked well for me, hope it will for others :)