### PR TITLE
Remove dead link

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -189,12 +189,6 @@
           <td>1900</td>
         </tr>
         <tr>
-          <td>Arch Linux 64 (2014-06-20)</td>
-          <td>VirtualBox</td>
-          <td>http://www.eduardoheredia.com.br/rep/vagrant/archlinux64.box</td>
-          <td>292</td>
-        </tr>
-        <tr>
           <td>Arch Linux 64 (2013-08-01)</td>
           <td>VirtualBox</td>
           <td>https://dl.dropboxusercontent.com/u/31112574/arch64-20130801.box</td>


### PR DESCRIPTION
Arch Linux 64 (2014-06-20) is 404'd. Domain doesn't exist.