### PR TITLE
Debian Jessie i386 added

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1930,6 +1930,12 @@
         <td>https://atlas.hashicorp.com/dusank/boxes/oi-desktop/versions/2015.05/providers/virtualbox.box</td>
         <td>5079</td>
       </tr>
+      <tr>
+       	<td>Debian Jessie i386 (bare minimal server for testing)</td>
+        <td>VirtualBox</td>
+        <td>https://pety.dynu.net/cloudbank_repo/debian_jessie_32bit.box</td>
+        <td>366</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Found no box for 32bit Debian Jessie, so I created one. Hope it is useful.