### PR TITLE
Fixing 404 (http://vagrant.t3log.pl/package.box isn't available) - should be removed 

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1907,12 +1907,6 @@
         <td>148</td>
       </tr>
       <tr>
-       	<td>TYPO3 on Ubntu 14.04 <br />PHP 5.5.9, MySQL 5.5.41, graphicsmagick, graphicsmagick-imagemagick-compat, php5-gd. MySQL password: password  </td>
-        <td>Vagrant</td>
-        <td>http://vagrant.t3log.pl/package.box</td>
-        <td>670</td>
-        </tr>
-      <tr>
        	<td>Debian Squeeze i386 (bare minimal server for testing)</td>
         <td>VirtualBox</td>
         <td>https://pety.dynu.net/cloudbank_repo/debian_squeeze_32bit.box</td>


### PR DESCRIPTION
Following box doesn't available. it shows 404. 

TYPO3 on Ubntu 14.04 
PHP 5.5.9, MySQL 5.5.41, graphicsmagick, graphicsmagick-imagemagick-compat, php5-gd. MySQL password: password