### PR TITLE
Update Oracle Linux 6.6 x86_64 base box to 6.7

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1317,10 +1317,10 @@
           <td>445</td>
         </tr>
         <tr>
-          <td>Oracle Linux 6.6 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-6-x86_64.md">src</a>)</td>
+          <td>Oracle Linux 6.7 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-6-x86_64.md">src</a>)</td>
           <td>VirtualBox</td>
           <td>http://cloud.terry.im/vagrant/oraclelinux-6-x86_64.box</td>
-          <td>711</td>
+          <td>727</td>
         </tr>
         <tr>
           <td>Oracle Linux 7.1 x86_64 (Chef + Puppet) (<a href="https://github.com/terrywang/vagrantboxes/blob/master/oraclelinux-7-x86_64.md">src</a>)</td>


### PR DESCRIPTION
Updated Oracle Linux 6.6 x86_64 base box to 6.7.

EOF