### PR TITLE
"FreeBSD 10.1 x86_64 Minimal (VirtualBox, ZFS)" returns a 404.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -690,12 +690,6 @@
           <td>336</td>
         </tr>
         <tr>
-          <td>FreeBSD 10.1 x86_64 Minimal (VirtualBox, ZFS)</td>
-          <td>VirtualBox</td>
-          <td>http://files.wunki.org/freebsd-10.1-amd64-wunki.box</td>
-          <td>445</td>
-        </tr>
-        <tr>
           <td>FreeBSD 9.2 i386 (UFS, VirtualBox Guest Additions 4.2.18, pkgng enabled, Python 2.7)
             [<a href="https://github.com/arkadijs/vagrant-freebsd/tree/9.2">source</a>]
           </td>


### PR DESCRIPTION
The owner of the file with the title [FreeBSD 10.1 x86_64 Minimal (VirtualBox, ZFS)](http://files.wunki.org/freebsd-10.1-amd64-wunki.box) seems to have deleted the file so that it now returns a 404.