### PR TITLE
Update index.html

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -105,6 +105,12 @@
       </thead>
       <tbody>
       	<tr>
+          <td>CentOS 7.2 Release x64 (Minimal + Puppet 4.3.1 + SELinux Enforcing, Guest Additions 4.3.30)</td>
+          <td>VirtualBox</td>
+          <td>https://www.dropbox.com/s/7u194d6reyr1loe/vagrant-centos-7.2.box?dl=0</td>
+          <td>600</td>
+        </tr>
+      	<tr>
           <td>Debian Jessie 8.1.0 Release x64 (Minimal, Guest Additions 4.3.26)</td>
           <td>VirtualBox</td>
           <td>https://atlas.hashicorp.com/ARTACK/boxes/debian-jessie</td>


### PR DESCRIPTION
CentOS 7.2 Release x64 (Minimal + Puppet 4.3.1 + SELinux Enforcing, Guest Additions 4.3.30) has been added.
