### PR TITLE
Debian Jessie 8.2.0

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -90,6 +90,12 @@
       </thead>
       <tbody>
       	<tr>
+          <td>Debian Jessie 8.2.0 Release x64 (Minimal, Guest Additions 5.0.10, Chef 12.5.1, Puppet 3.7.2)</td>
+          <td>VirtualBox</td>
+          <td>https://github.com/shtouff/vagrant-debian-jessie-64/releases/download/debian-jessie-8-2_vbox-5-0-10/debian-jessie-64-82_vbox-5-0-10.box</td>
+          <td>517</td>
+        </tr>
+      	<tr>
           <td>Virtuozzo 7 x64 (Guest Additions 4.3.26)</td>
           <td>VirtualBox</td>
           <td>https://atlas.hashicorp.com/OpenVZ/boxes/Virtuozzo-7b2</td>


### PR DESCRIPTION
Hi there

I uploaded a new box, built with https://github.com/shtouff/vagrant-debian-jessie-64/

- debian jessie 8.2.0
- vbox guest additions 5.0.10
- chef 12.5.1
- puppet 3.7.2

Size: 517 Mb