### PR TITLE
Remove obsolete elixir image

### DIFF
--- a/index.html
+++ b/index.html
@@ -1865,12 +1865,6 @@
         <td>800</td>
       </tr>
       <tr>
-        <td>Ubuntu precise 64 VirtualBox + Erlang OTP 17 + Elixir 0.13.3</td>
-        <td>VirtualBox</td>
-        <td>https://dl.dropboxusercontent.com/s/37x8l9myg45ql2e/elixir.box</td>
-        <td>742.2</td>
-      </tr>
-      <tr>
         <td>Ubuntu Server Precise 12.04 amd64 (chef, puppet)</td>
         <td>Parallels</td>
         <td>http://download.parallels.com/desktop/vagrant/precise64.box</td>


### PR DESCRIPTION
Elixir lang is currently at 1.3. As the languge changed a lot since this image was published, I'm removing it from dropbox and also removing the entry of available vagrant images.
