### PR TITLE
Updated Ubuntu-16.04 LTS VirtualBox w/Docker enabled.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2134,8 +2134,8 @@
         <tr>
           <td>Ubuntu 16.04 with Docker enabled (based on amd64 server iso file)</td>
           <td>VirtualBox</td>
-          <td>https://github.com/jose-lpa/packer-ubuntu_lts/releases/download/v3.0/ubuntu-16.04.box</td>
-          <td>533</td>
+          <td>https://github.com/jose-lpa/packer-ubuntu_lts/releases/download/v3.1/ubuntu-16.04.box</td>
+          <td>567</td>
         </tr>
       <tr>
         <td>CentOS 6 x86_64 minimal installation</td>


### PR DESCRIPTION
Link to the new version of the box after fixing a base system configuration issue.