### PR TITLE
Added RHEL6 and RHEL7 vagrant boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,18 @@
         <tr><th>Name</th><th>Provider</th><th>URL</th><th>Size (MB)</th></tr>
       </thead>
       <tbody>
+        <tr>
+	  <td>RHEL7.3 (Guest Additions 5.1.18)</td>
+	  <td>VirtualBox</td>
+          <td>https://vagrantcloud.com/samdoran/boxes/rhel7</td>
+	  <td>554</td>
+	</tr>
+        <tr>
+	  <td>RHEL6.9 (Guest Additions 5.1.18)</td>
+	  <td>VirtualBox</td>
+          <td>https://vagrantcloud.com/samdoran/boxes/rhel6</td>
+	  <td>602</td>
+	</tr>
       	<tr>
           <td>Virtuozzo 7 x64 (Guest Additions 4.3.26)</td>
           <td>VirtualBox</td>


### PR DESCRIPTION
Hi,

I added RHEL6 and RHEL7 boxes that I found in vagrantcloud. Seems to be working for me so I hope this would be useful to vagrantbox.es users.